### PR TITLE
[RTL-sim] Fix DMA write strobe widths in vcs tick

### DIFF
--- a/src/main/cc/emul/mmio_f1.cc
+++ b/src/main/cc/emul/mmio_f1.cc
@@ -109,6 +109,7 @@ void* init(uint64_t memsize, bool dramsim) {
 #ifdef VCS
 static const size_t MASTER_DATA_SIZE = MMIO_WIDTH / sizeof(uint32_t);
 static const size_t DMA_DATA_SIZE = DMA_WIDTH / sizeof(uint32_t);
+static const size_t DMA_STRB_SIZE = (DMA_WIDTH/8 + sizeof(uint32_t) - 1) / sizeof(uint32_t);
 static const size_t SLAVE_DATA_SIZE = MEM_WIDTH / sizeof(uint32_t);
 extern midas_context_t* host;
 extern bool vcs_fin;
@@ -217,6 +218,7 @@ void tick(
   mmio_f1_t *m, *d;
   assert(m = dynamic_cast<mmio_f1_t*>(master.get()));
   assert(d = dynamic_cast<mmio_f1_t*>(dma.get()));
+  assert(DMA_STRB_SIZE <= 2);
 
   uint32_t master_r_data[MASTER_DATA_SIZE];
   for (size_t i = 0 ; i < MASTER_DATA_SIZE ; i++) {
@@ -318,8 +320,12 @@ void tick(
   dd[0].c = 0;
   dd[0].d = d->ar_len();
   vc_put4stVector(dma_ar_bits_len, dd);
-  dd[0].c = 0;
-  dd[0].d = d->w_strb();
+
+  auto strb = d->w_strb();
+  for (size_t i = 0 ; i < DMA_STRB_SIZE ; i++) {
+    dd[i].c = 0;
+    dd[i].d = ((uint32_t*)(&strb))[i];
+  }
   vc_put4stVector(dma_w_bits_strb, dd);
 
   for (size_t i = 0 ; i < DMA_DATA_SIZE ; i++) {

--- a/src/main/cc/simif_emul.cc
+++ b/src/main/cc/simif_emul.cc
@@ -176,12 +176,12 @@ ssize_t simif_emul_t::push(size_t addr, char *data, size_t size) {
   size_t *strb_ptr = &strb[0];
 
   for (int i = 0; i < len; i++)
-      strb[i] = (1L << DMA_WIDTH) - 1;
+      strb[i] = (1LL << DMA_WIDTH) - 1;
 
   if (remaining == DMA_WIDTH)
       strb[len] = strb[0];
   else
-      strb[len] = (1L << remaining) - 1;
+      strb[len] = (1LL << remaining) - 1;
 
   while (len >= 0) {
       size_t part_len = len % (MAX_LEN + 1);


### PR DESCRIPTION
This is a partial solution to https://github.com/firesim/firesim/issues/107. Now something more sensible needs to be done to actually model network stimulus in VCS. 

What sort of tests were done in verilator @zhemao? Just loopback? 