### PR TITLE
Fix init tokens

### DIFF
--- a/src/main/cc/simif.cc
+++ b/src/main/cc/simif.cc
@@ -55,6 +55,7 @@ void simif_t::init(int argc, char** argv, bool log) {
 }
 
 void simif_t::target_reset(int pulse_start, int pulse_length) {
+#ifdef reset
   poke(reset, 0);
   take_steps(pulse_start, true);
   poke(reset, 1);
@@ -65,6 +66,7 @@ void simif_t::target_reset(int pulse_start, int pulse_length) {
   trace_count = std::min((size_t)(pulse_start + pulse_length), tracelen);
   read_traces(NULL);
   trace_count = 0;
+#endif
 #endif
 }
 
@@ -91,8 +93,8 @@ void simif_t::poke(size_t id, mpz_t& value) {
   }
   size_t size;
   data_t* data = (data_t*)mpz_export(NULL, &size, -1, sizeof(data_t), 0, 0, value);
-  for (size_t i = 0 ; i < INPUT_CHUNKS[id] ; i++) {
-    write(INPUT_ADDRS[id]+i, i < size ? data[i] : 0);
+  for (size_t i = 0 ; i < (const size_t)INPUT_CHUNKS[id] ; i++) {
+    write((size_t)INPUT_ADDRS[id]+i, i < size ? data[i] : 0);
   }
 }
 

--- a/src/main/cc/simif.h
+++ b/src/main/cc/simif.h
@@ -62,8 +62,8 @@ class simif_t
 
     inline void poke(size_t id, data_t value) {
       if (log) fprintf(stderr, "* POKE %s.%s <- 0x%x *\n",
-        TARGET_NAME, INPUT_NAMES[id], value);
-      write(INPUT_ADDRS[id], value);
+        TARGET_NAME, ((const char*)INPUT_NAMES)[id], value);
+      write(((unsigned int*)INPUT_ADDRS)[id], value);
     }
 
     inline data_t peek(size_t id) {

--- a/src/main/cc/simif_zynq.h
+++ b/src/main/cc/simif_zynq.h
@@ -18,7 +18,11 @@ class simif_zynq_t: public virtual simif_t
   protected:
     virtual void write(size_t addr, uint32_t data);
     virtual uint32_t read(size_t addr);
-    virtual size_t pread(size_t addr, char* data, size_t size) {
+    virtual ssize_t push(size_t addr, char* data, size_t size) {
+      // Not supported
+      return 0;
+    }
+    virtual ssize_t pull(size_t addr, char* data, size_t size) {
       // Not supported
       return 0;
     }

--- a/src/main/scala/midas/Config.scala
+++ b/src/main/scala/midas/Config.scala
@@ -35,6 +35,8 @@ class SimConfig extends Config((site, here, up) => {
   case FpgaMMIOSize     => BigInt(1) << 12 // 4 KB
   case MidasLLCKey      => None
   case AXIDebugPrint    => false
+  // WARNING: if it's false, simulation be much slower
+  // unless widgets initiailze output tokens by themselves
   case HasInitTokens    => true
 })
 

--- a/src/main/scala/midas/Config.scala
+++ b/src/main/scala/midas/Config.scala
@@ -35,6 +35,7 @@ class SimConfig extends Config((site, here, up) => {
   case FpgaMMIOSize     => BigInt(1) << 12 // 4 KB
   case MidasLLCKey      => None
   case AXIDebugPrint    => false
+  case HasInitTokens    => true
 })
 
 class ZynqConfig extends Config(new Config((site, here, up) => {

--- a/src/main/scala/midas/core/Channel.scala
+++ b/src/main/scala/midas/core/Channel.scala
@@ -23,6 +23,7 @@ class WireChannel(val w: Int)(implicit p: Parameters) extends Module {
   val tokens = Module(new Queue(UInt(w.W), p(ChannelLen)))
   tokens.io.enq <> io.in
   io.out <> tokens.io.deq
+  when(false.B) { printf("%d", tokens.io.count) }
   if (p(EnableSnapshot)) {
     io.trace <> TraceQueue(tokens.io.deq, io.traceLen)
   } else {

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -162,6 +162,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
       widget.io.tReset <> resetQueue.io.deq
       resetQueue.io.enq.bits := defaultIOWidget.io.tReset.bits
       resetQueue.io.enq.valid := defaultIOWidget.io.tReset.valid
+      when(false.B) { printf("%d", resetQueue.io.count) }
       ready && resetQueue.io.enq.ready
     }
   }

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 case object MemNastiKey extends Field[NastiParameters]
 case object DMANastiKey extends Field[NastiParameters]
 case object FpgaMMIOSize extends Field[BigInt]
+case object HasInitTokens extends Field[Boolean]
 
 class FPGATopIO(implicit p: Parameters) extends WidgetIO {
   val dma  = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
@@ -84,7 +85,8 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
           case ActualDirection.Input =>
             import chisel3.core.ExplicitCompileOptions.NotStrict // to connect nasti & axi4
             channel.target <> target
-            channel.host.hValid := port.fromHost.hValid || simResetNext
+            channel.host.hValid := port.fromHost.hValid ||
+              (if (p(HasInitTokens)) simResetNext else false.B)
             ready += channel.host.hReady
           case ActualDirection.Output =>
             import chisel3.core.ExplicitCompileOptions.NotStrict // to connect nasti & axi4
@@ -103,8 +105,9 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
         case ActualDirection.Input =>
           val channels = simIo.getIns(wire)
           channels.zipWithIndex foreach { case (in, i) =>
-            in.bits  := target >> UInt(i * simIo.channelWidth)
-            in.valid := port.fromHost.hValid || simResetNext
+            in.bits  := target >> (i * simIo.channelWidth).U
+            in.valid := port.fromHost.hValid ||
+              (if (p(HasInitTokens)) simResetNext else false.B)
           }
           ready ++= channels map (_.ready)
         case ActualDirection.Output =>
@@ -133,7 +136,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
   val dmaPorts = new ListBuffer[NastiIO]
 
   // Instantiate endpoint widgets
-  defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft Bool(true)){ (resetReady, endpoint) =>
+  defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft true.B){ (resetReady, endpoint) =>
     ((0 until endpoint.size) foldLeft resetReady){ (ready, i) =>
       val widgetName = (endpoint, p(MemModelKey)) match {
         case (_: SimMemIO, Some(_)) => s"MemModel_$i"

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -17,8 +17,14 @@ case object DMANastiKey extends Field[NastiParameters]
 case object FpgaMMIOSize extends Field[BigInt]
 case object HasInitTokens extends Field[Boolean]
 
+object DMAIO {
+  def apply()(implicit p: Parameters): NastiIO = {
+    Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
+  }
+}
+
 class FPGATopIO(implicit p: Parameters) extends WidgetIO {
-  val dma  = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
+  val dma = DMAIO()
   val mem = new NastiIO()(p alterPartial ({ case NastiKey => p(MemNastiKey) }))
 }
 
@@ -133,7 +139,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
     arb.io.master(memIoSize) <> loadMem.io.toSlaveMem
   }
 
-  val dmaPorts = new ListBuffer[NastiIO]
+  val dmaPorts = ListBuffer[NastiIO]()
 
   // Instantiate endpoint widgets
   defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft true.B){ (resetReady, endpoint) =>

--- a/src/main/scala/midas/core/SimWrapper.scala
+++ b/src/main/scala/midas/core/SimWrapper.scala
@@ -345,7 +345,7 @@ class SimWrapper(targetIo: Seq[Data])
   // Cycles for debug
   val cycles = Reg(UInt(64.W))
   when (fire) {
-    // cycles := Mux(target.io.reset, UInt(0), cycles + UInt(1))
+    cycles := Mux(targetReset.toBool, 0.U, cycles + 1.U)
     when(false.B) { printf("%d", cycles) }
   }
 } 

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -11,8 +11,8 @@ import midas.core.DMANastiKey
 case object AXIDebugPrint extends Field[Boolean]
 
 class F1ShimIO(implicit p: Parameters) extends ParameterizedBundle()(p) {
+  val dma    = midas.core.DMAIO()
   val master = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(MasterNastiKey) })))
-  val dma    = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
   val slave  = new NastiIO()(p alterPartial ({ case NastiKey => p(SlaveNastiKey) }))
 }
 

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -92,10 +92,14 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
   io.step.ready := io.idle
 
   // Target reset connection
-  io.tReset.bits := io.ins(0).bits(0)
-  io.tReset.valid := io.ins(0).valid
-
-  genCRFile()
+  if (io.ins.nonEmpty) {
+    io.tReset.bits := io.ins(0).bits(0)
+    io.tReset.valid := io.ins(0).valid
+    genCRFile()
+  } else {
+    io.tReset := chisel3.core.DontCare
+    io.ctrl   := chisel3.core.DontCare
+  }
 
   override def genHeader(base: BigInt, sb: StringBuilder): Unit = {
     import CppGenerationUtils._

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -92,10 +92,8 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
   io.step.ready := io.idle
 
   // Target reset connection
-  // Hack: insert high to resetQueue as initial tokens
-  val resetNext = RegNext(reset)
-  io.tReset.bits := resetNext || io.ins(0).bits(0)
-  io.tReset.valid := resetNext || io.ins(0).valid
+  io.tReset.bits := io.ins(0).bits(0)
+  io.tReset.valid := io.ins(0).valid
 
   genCRFile()
 


### PR DESCRIPTION
These are some changes for init token issues:
1. There's no reason to generate init tokens for target resets toward widgets as discussed with @davidbiancolin 
2. Forced init token injections for widgets may not be desirable in some cases (e.g. widgets act like `PeekPokeIOWidget`). Thus, I added a parameter to make it optional. 

