### PR TITLE
Add +dump-cycles plusarg for limiting waveform duration

### DIFF
--- a/src/main/verilog/emul_zynq.v
+++ b/src/main/verilog/emul_zynq.v
@@ -79,6 +79,8 @@ module emul;
 
   reg [2047:0] vcdplusfile = 0;
   reg [63:0] dump_start = 0;
+  reg [63:0] dump_end = {64{1'b1}};
+  reg [63:0] dump_cycles = 0;
   reg [63:0] trace_count = 0;
 
   initial begin
@@ -86,7 +88,18 @@ module emul;
     if ($value$plusargs("waveform=%s", vcdplusfile))
     begin
       $value$plusargs("dump-start=%d", dump_start);
+      if ($value$plusargs("dump-cycles=%d", dump_cycles)) begin
+        dump_end = dump_start + dump_cycles;
+      end
+
       $vcdplusfile(vcdplusfile);
+      wait (trace_count >= dump_start) begin
+        $vcdpluson(0);
+        $vcdplusmemon(0);
+      end
+      wait ((trace_count > dump_end) || fin) begin
+        $vcdplusclose;
+      end
     end
 `endif
   end
@@ -353,15 +366,6 @@ module emul;
   );
 
   always @(posedge clock) begin
-`ifdef DEBUG
-    if (fin) begin
-      $vcdplusclose;
-    end
-    if (trace_count == dump_start) begin
-      $vcdpluson(0);
-      $vcdplusmemon(0);
-    end
-`endif
     trace_count = trace_count + 1;
     tick(
       reset,


### PR DESCRIPTION
I haven't yet found a workaround for VCS segfaulting when `$vcdplusclose` is called early, and VCS+HTIF still doesn't quite exit cleanly when adding `$finish`, so for now let's pretend as if everything works as intended.

This includes some minor refactoring to consolidate all VPD-related statements in the same `initial` block.