### PR TITLE
MIDAS 0.3.2 Release

### DIFF
--- a/src/main/cc/emul/mmio_f1.cc
+++ b/src/main/cc/emul/mmio_f1.cc
@@ -101,7 +101,7 @@ std::unique_ptr<mm_t> slave;
 void* init(uint64_t memsize, bool dramsim) {
   master.reset(new mmio_f1_t(MMIO_WIDTH));
   dma.reset(new mmio_f1_t(DMA_WIDTH));
-  slave.reset(dramsim ? (mm_t*) new mm_dramsim2_t : (mm_t*) new mm_magic_t);
+  slave.reset(dramsim ? (mm_t*) new mm_dramsim2_t(1 << MEM_ID_BITS) : (mm_t*) new mm_magic_t);
   slave->init(memsize, MEM_WIDTH, 64);
   return slave->get_data();
 }

--- a/src/main/cc/emul/mmio_zynq.cc
+++ b/src/main/cc/emul/mmio_zynq.cc
@@ -102,7 +102,7 @@ std::unique_ptr<mm_t> slave;
 
 void* init(uint64_t memsize, bool dramsim) {
   master.reset(new mmio_zynq_t);
-  slave.reset(dramsim ? (mm_t*) new mm_dramsim2_t : (mm_t*) new mm_magic_t);
+  slave.reset(dramsim ? (mm_t*) new mm_dramsim2_t(1 << MEM_ID_BITS) : (mm_t*) new mm_magic_t);
   slave->init(memsize, MEM_WIDTH, 64);
   return slave->get_data();
 }

--- a/src/main/cc/utils/mm.cc
+++ b/src/main/cc/utils/mm.cc
@@ -17,9 +17,13 @@ void mm_base_t::write(uint64_t addr, uint8_t *data) {
 
 void mm_base_t::write(uint64_t addr, uint8_t *data, uint64_t strb, uint64_t size)
 {
-  strb &= ((1L << size) - 1) << (addr % word_size);
-  addr %= this->size;
+  if (addr > this->size) {
+    char buf[80];
+    snprintf(buf, 80, "Out-of-bounds write @ address: 0x%lx Memory size: 0x%lx\n", addr, this->size);
+    throw(mm_exception(buf));
+  }
 
+  strb &= ((1L << size) - 1) << (addr % word_size);
   uint8_t *base = this->data + (addr / word_size) * word_size;
   for (int i = 0; i < word_size; i++) {
     if (strb & 1)
@@ -28,10 +32,14 @@ void mm_base_t::write(uint64_t addr, uint8_t *data, uint64_t strb, uint64_t size
   }
 }
 
+
 std::vector<char> mm_base_t::read(uint64_t addr)
 {
-  addr %= this->size;
-
+  if (addr > this->size) {
+    char buf[80];
+    snprintf(buf, 80, "Out-of-bounds read @ address: 0x%lx Memory size: 0x%lx\n", addr, this->size);
+    throw(mm_exception(buf));
+  }
   uint8_t *base = this->data + addr;
   return std::vector<char>(base, base + word_size);
 }

--- a/src/main/cc/utils/mm.h
+++ b/src/main/cc/utils/mm.h
@@ -6,6 +6,24 @@
 #include <stdint.h>
 #include <cstring>
 #include <queue>
+#include <string>
+#include <stdexcept>
+
+class mm_exception : public std::runtime_error {
+  public:
+    explicit mm_exception(const std::string& msg)  :
+      std::runtime_error(msg), msg_(msg) {};
+
+    virtual const char* what() const throw()
+    {
+      return msg_.c_str();
+    };
+
+    virtual ~mm_exception() throw () {};
+
+  private:
+    std::string msg_;
+};
 
 class mm_base_t
 {

--- a/src/main/cc/utils/mm_dramsim2.cc
+++ b/src/main/cc/utils/mm_dramsim2.cc
@@ -16,18 +16,23 @@ using namespace DRAMSim;
 
 void mm_dramsim2_t::read_complete(unsigned id, uint64_t address, uint64_t clock_cycle)
 {
-  mm_rresp_t resp;
-  do {
-    resp = rreq[address].front();
-    rresp.push(resp);
-    rreq[address].pop();
-  } while (!resp.last);
+  assert(!rreq[address].empty());
+  auto req = rreq[address].front();
+  uint64_t start_addr = (req.addr / word_size) * word_size;
+  for (size_t i = 0; i < req.len; i++) {
+    auto dat = read(start_addr + i * word_size);
+    rresp.push(mm_rresp_t(req.id, dat, (i == req.len - 1)));
+  }
+  read_id_busy[req.id] = false;
+  rreq[address].pop();
 }
 
 void mm_dramsim2_t::write_complete(unsigned id, uint64_t address, uint64_t clock_cycle)
 {
+  assert(!wreq[address].empty());
   auto b_id = wreq[address].front();
   bresp.push(b_id);
+  write_id_busy[b_id] = false;
   wreq[address].pop();
 }
 
@@ -44,12 +49,7 @@ void mm_dramsim2_t::init(size_t sz, int wsz, int lsz)
   dummy_data.resize(word_size);
 
   assert(size % (1024*1024) == 0);
-#ifndef _WIN32
-  std::string pwd = "dramsim2_ini";
-#else
-  std::string pwd = "";
-#endif
-  mem = new MultiChannelMemorySystem("DDR3_micron_64M_8B_x4_sg15.ini", "system.ini", pwd, "results", size/(1024*1024));
+  mem = getMemorySystemInstance(memory_ini, system_ini, ini_dir, "results", size/(1024*1024));
 
   TransactionCompleteCB *read_cb = new Callback<mm_dramsim2_t, void, unsigned, uint64_t, uint64_t>(this, &mm_dramsim2_t::read_complete);
   TransactionCompleteCB *write_cb = new Callback<mm_dramsim2_t, void, unsigned, uint64_t, uint64_t>(this, &mm_dramsim2_t::write_complete);
@@ -58,6 +58,14 @@ void mm_dramsim2_t::init(size_t sz, int wsz, int lsz)
 #ifdef DEBUG_DRAMSIM2
   fprintf(stderr,"Dramsim2 init successful\n");
 #endif
+}
+
+bool mm_dramsim2_t::ar_ready() {
+  return mem->willAcceptTransaction();
+}
+
+bool mm_dramsim2_t::aw_ready() {
+  return mem->willAcceptTransaction() && !store_inflight;
 }
 
 void mm_dramsim2_t::tick(
@@ -89,13 +97,21 @@ void mm_dramsim2_t::tick(
   bool r_fire = !reset && r_valid() && r_ready;
   bool b_fire = !reset && b_valid() && b_ready;
 
-  if (ar_fire) {
-    uint64_t start_addr = (ar_addr / word_size) * word_size;
-    for (size_t i = 0; i <= ar_len; i++) {
-      auto dat = read(start_addr + i * word_size);
-      rreq[ar_addr].push(mm_rresp_t(ar_id, dat, (i == ar_len)));
+  if (mem->willAcceptTransaction()) {
+    for (auto it = rreq_queue.begin(); it != rreq_queue.end(); it++) {
+      if (!read_id_busy[it->id]) {
+        read_id_busy[it->id] = true;
+        auto transaction = *it;
+        rreq[transaction.addr].push(transaction);
+        mem->addTransaction(false, transaction.addr);
+        rreq_queue.erase(it);
+        break;
+      }
     }
-    mem->addTransaction(false, ar_addr);
+  }
+
+  if (ar_fire) {
+    rreq_queue.push_back(mm_req_t(ar_id, 1 << ar_size, ar_len + 1, ar_addr));
   }
 
   if (aw_fire) {

--- a/src/main/scala/midas/Compiler.scala
+++ b/src/main/scala/midas/Compiler.scala
@@ -2,6 +2,8 @@
 
 package midas
 
+import passes.Utils.writeEmittedCircuit
+
 import chisel3.{Data, Bundle, Record, Clock, Bool}
 import chisel3.internal.firrtl.Port
 import firrtl.ir.Circuit
@@ -26,15 +28,22 @@ private class MidasCompiler extends firrtl.Compiler {
     getLoweringTransforms(firrtl.MidForm, firrtl.LowForm)
 }
 
-// Compilers to emit proper verilog
-private class VerilogCompiler extends firrtl.Compiler {
-  def emitter = new firrtl.VerilogEmitter
+// These next two compilers split LFO from the rest of the lowering
+// compilers to schedule around the presence of internal & non-standard WIR
+// nodes (Dshlw) present after LFO, which custom transforms can't handle
+private class HostTransformCompiler extends firrtl.Compiler {
+  def emitter = new firrtl.LowFirrtlEmitter
   def transforms =
     Seq(new firrtl.IRToWorkingIR,
         new firrtl.ResolveAndCheck,
         new firrtl.HighFirrtlToMiddleFirrtl) ++
-    getLoweringTransforms(firrtl.MidForm, firrtl.LowForm) ++
-    Seq(new firrtl.LowFirrtlOptimization)
+    getLoweringTransforms(firrtl.MidForm, firrtl.LowForm)
+}
+
+// Custom transforms have been scheduled -> do the final lowering
+private class LastStageVerilogCompiler extends firrtl.Compiler {
+  def emitter = new firrtl.VerilogEmitter
+  def transforms = Seq(new firrtl.LowFirrtlOptimization)
 }
 
 object MidasCompiler {
@@ -44,7 +53,9 @@ object MidasCompiler {
       io: Seq[Data],
       dir: File,
       lib: Option[File],
-      customTransforms: Seq[Transform])
+      targetTransforms: Seq[Transform], // Run pre-MIDAS transforms, on the target RTL
+      hostTransforms: Seq[Transform]    // Run post-MIDAS transformations
+    )
      (implicit p: Parameters): CircuitState = {
     val conf = new File(dir, s"${chirrtl.main}.conf")
     val json = new File(dir, s"${chirrtl.main}.macros.json")
@@ -57,13 +68,12 @@ object MidasCompiler {
     val compiler = new MidasCompiler
     val midas = compiler.compile(firrtl.CircuitState(
       chirrtl, firrtl.ChirrtlForm, targetAnnos ++ midasAnnos),
-      customTransforms :+ midasTransforms)
+      targetTransforms :+ midasTransforms)
 
-    val result = (new VerilogCompiler).compileAndEmit(firrtl.CircuitState(
-      midas.circuit, firrtl.HighForm, midasAnnos))
-    val verilog = new FileWriter(new File(dir, s"FPGATop.v"))
-    verilog.write(result.getEmittedCircuit.value)
-    verilog.close
+    val postHostTransforms = new HostTransformCompiler().compile(midas, hostTransforms)
+    val result = new LastStageVerilogCompiler().compileAndEmit(postHostTransforms)
+
+    writeEmittedCircuit(result, new File(dir, s"FPGATop.v"))
     result
   }
 
@@ -72,13 +82,15 @@ object MidasCompiler {
       w: => T,
       dir: File,
       libFile: Option[File] = None,
-      customTransforms: Seq[Transform] = Nil)
+      targetTransforms: Seq[Transform] = Seq.empty,
+      hostTransforms: Seq[Transform] = Seq.empty
+    )
      (implicit p: Parameters): CircuitState = {
     dir.mkdirs
     lazy val target = w
     val circuit = chisel3.Driver.elaborate(() => target)
     val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))
     val io = target.getPorts map (_.id)
-    apply(chirrtl, circuit.annotations.map(_.toFirrtl), io, dir, libFile, customTransforms)
+    apply(chirrtl, circuit.annotations.map(_.toFirrtl), io, dir, libFile, targetTransforms, hostTransforms)
   }
 }

--- a/src/main/scala/midas/core/SimWrapper.scala
+++ b/src/main/scala/midas/core/SimWrapper.scala
@@ -326,7 +326,7 @@ class SimWrapper(targetIo: Seq[Data])
           (wireOutChannels foldLeft true.B)(_ && _.io.in.ready) &&
           (readyValidInChannels foldLeft true.B)(_ && _.io.deq.host.hValid) &&
           (readyValidOutChannels foldLeft true.B)(_ && _.io.enq.host.hReady)
- 
+
   // Inputs are consumed when firing conditions are met
   wireInChannels foreach (_.io.out.ready := fire)
   readyValidInChannels foreach (_.io.deq.host.hReady := fire)

--- a/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/src/main/scala/midas/passes/MidasTransforms.scala
@@ -82,3 +82,13 @@ class Fame1Instances extends Transform {
   }
 }
 
+// This is currently implemented by the enclosing project
+case class FpgaDebugAnnotation(target: chisel3.core.Data)
+    extends chisel3.experimental.ChiselAnnotation {
+  def toFirrtl = FirrtlFpgaDebugAnnotation(target.toNamed)
+}
+
+case class FirrtlFpgaDebugAnnotation(target: ComponentName) extends
+    SingleTargetAnnotation[ComponentName] {
+  def duplicate(n: ComponentName) = this.copy(target = n)
+}

--- a/src/main/scala/midas/passes/PlatformMapping.scala
+++ b/src/main/scala/midas/passes/PlatformMapping.scala
@@ -4,6 +4,7 @@ package midas
 package passes
 
 import firrtl._
+import firrtl.annotations.{CircuitName}
 import firrtl.ir._
 import firrtl.Mappers._
 import Utils._
@@ -12,9 +13,11 @@ import java.io.{File, FileWriter, StringWriter}
 private[passes] class PlatformMapping(
     target: String,
     dir: File)
-    (implicit param: freechips.rocketchip.config.Parameters) extends firrtl.passes.Pass {
+  (implicit param: freechips.rocketchip.config.Parameters) extends firrtl.Transform {
 
-  override def name = "[midas] Platform Mapping"
+  def inputForm = LowForm
+  def outputForm = HighForm
+  override def name = "[MIDAS] Platform Mapping"
 
   private def dumpHeader(c: platform.PlatformShim) {
     def vMacro(arg: (String, Int)): String = s"`define ${arg._1} ${arg._2}\n"
@@ -60,20 +63,30 @@ private[passes] class PlatformMapping(
     case m: ExtModule => None
   }
 
-  def run(c: Circuit) = {
-    val sim = c match { case w: WCircuit => w.sim }
+  def linkCircuits(parent: Circuit, child: Circuit): Circuit = {
+    parent.copy(modules = child.modules ++ (parent.modules flatMap init(child.info, child.main)))
+  }
+
+  def execute(c: CircuitState) = {
+    val sim = c.circuit match { case w: WCircuit => w.sim }
     lazy val shim = param(Platform) match {
       case Zynq     => new platform.ZynqShim(sim)
       case F1       => new platform.F1Shim(sim)
     }
-    val c3circuit = chisel3.Driver.elaborate(() => shim)
-    val chirrtl = Parser.parse(chisel3.Driver.emit(c3circuit))
-    val annos = c3circuit.annotations.map(_.toFirrtl)
-    val circuit = renameMods((new LowFirrtlCompiler().compile(
-                                CircuitState(chirrtl, ChirrtlForm, annos),
-                                new StringWriter, Seq(new Fame1Instances))
-                              ).circuit, Namespace(c))
+    val shimCircuit = chisel3.Driver.elaborate(() => shim)
+    val chirrtl = Parser.parse(chisel3.Driver.emit(shimCircuit))
+    val shimAnnos = shimCircuit.annotations.map(_.toFirrtl)
+    val transforms = Seq(new Fame1Instances,
+                         new PreLinkRenaming(Namespace(c.circuit)))
+    val shimCircuitState = new LowFirrtlCompiler().compile(CircuitState(chirrtl, ChirrtlForm, shimAnnos), transforms)
+
+    // Rename the annotations from the inner module, which are using an obselete CircuitName
+    val renameMap = RenameMap(
+      Map(CircuitName(c.circuit.main) -> Seq(CircuitName(shimCircuitState.circuit.main))))
+
     dumpHeader(shim)
-    circuit.copy(modules = c.modules ++ (circuit.modules flatMap init(c.info, c.main)))
+    c.copy(circuit = linkCircuits(shimCircuitState.circuit, c.circuit),
+           annotations = shimCircuitState.annotations ++ c.annotations,
+           renames = Some(renameMap))
   }
 }

--- a/src/main/scala/midas/passes/PreLinkRenaming.scala
+++ b/src/main/scala/midas/passes/PreLinkRenaming.scala
@@ -1,0 +1,53 @@
+// See LICENSE for license details.
+
+package midas.passes
+
+import firrtl._
+import firrtl.annotations.{CircuitName, ModuleName}
+import firrtl.ir._
+import firrtl.Mappers._
+import Utils._
+import java.io.{File, FileWriter, StringWriter}
+
+// This transform renames a wrapper circuit's modules and annotations in
+// preparation for linking (eg. PlatformMapping). Subsumes Utils.renameMods
+// We want to preserve the module names of the circuit we are wrapping (the child),
+// so we reference its namespace to generate new names.
+private[passes] class PreLinkRenaming(childNamespace: Namespace) extends firrtl.Transform {
+
+  override def name = "[MIDAS] Pre-link Module Renaming"
+  // TODO: Technically this xform should be able to accept AnyForm(TM); and be form idempotent
+  def inputForm = LowForm
+  def outputForm = LowForm
+
+  // Updates instantiations of modules that would alias
+  def updateInsts(nameMap: Map[String, String])(s: Statement): Statement = s match {
+    case s: WDefInstance => s.copy(module = nameMap(s.module))
+    case s => s.map(updateInsts(nameMap))
+  }
+  // Renames the module if there is a collision, and updates submodule inst names
+  def updateModNames(nameMap: Map[String, String])(m: DefModule): DefModule = (m match {
+      case m : ExtModule => m.copy(name = nameMap(m.name))
+      case m :    Module => m.copy(name = nameMap(m.name))
+  }) map updateInsts(nameMap)
+
+  def execute(state: CircuitState): CircuitState = {
+    val circuit = state.circuit
+    require(!childNamespace.contains(circuit.main), "Submodule in child has same name as parent's top")
+
+    // Generate new names for all modules of our circuit -- if the original name
+    // is not present in the child's namespace, it is preserved
+    val namePairs = circuit.modules.map(m => m.name -> childNamespace.newName(m.name))
+
+    // Generate a rename map to update annotations that reference de-aliased modules
+    val cname = CircuitName(circuit.main)
+    val renameMap = RenameMap(namePairs.map({
+      case (from, to) => ModuleName(from,cname) -> Seq(ModuleName(to,cname))
+    }).toMap)
+
+    renameMap.setCircuit(circuit.main)
+
+    state.copy(circuit = circuit.copy(modules = circuit.modules map updateModNames(namePairs.toMap)),
+               renames = Some(renameMap))
+  }
+}

--- a/src/main/scala/midas/passes/SimulationMapping.scala
+++ b/src/main/scala/midas/passes/SimulationMapping.scala
@@ -6,11 +6,11 @@ package passes
 import java.io.{File, FileWriter, StringWriter}
 
 import firrtl._
+import firrtl.annotations.{CircuitName}
 import firrtl.ir._
 import firrtl.Mappers._
-import firrtl.Utils.BoolType
 import firrtl.passes.LowerTypes.loweredName
-import firrtl.Utils.{splitRef, mergeRef, create_exps, gender, module_type}
+import firrtl.Utils.{BoolType, splitRef, mergeRef, create_exps, gender, module_type}
 import Utils._
 import freechips.rocketchip.config.Parameters
 
@@ -18,9 +18,11 @@ import midas.core.SimWrapper
 
 private[passes] class SimulationMapping(
     io: Seq[chisel3.Data])
-   (implicit param: Parameters) extends firrtl.passes.Pass {
-  
-  override def name = "[midas] Simulation Mapping"
+  (implicit param: Parameters) extends firrtl.Transform {
+
+  def inputForm = LowForm
+  def outputForm = HighForm
+  override def name = "[MIDAS] Simulation Mapping"
 
   private def initStmt(target: String)(s: Statement): Statement =
     s match {
@@ -53,20 +55,31 @@ private[passes] class SimulationMapping(
     case m: ExtModule => None
   }
 
-  def run(c: Circuit) = {
+  def execute(innerState: CircuitState) = {
+    val innerCircuit = innerState.circuit
     lazy val sim = new SimWrapper(io)
     val c3circuit = chisel3.Driver.elaborate(() => sim)
     val chirrtl = Parser.parse(chisel3.Driver.emit(c3circuit))
     val annos = c3circuit.annotations.map(_.toFirrtl)
-    val writer = new StringWriter
-    // val writer = new FileWriter(new File("SimWrapper.ir"))
-    val circuit = renameMods((new LowFirrtlCompiler compile (
-        CircuitState(chirrtl, ChirrtlForm, annos), writer)
-      ).circuit, Namespace(c))
-    val targetType = module_type((c.modules find (_.name == c.main)).get)
-    val modules = c.modules ++ (circuit.modules flatMap
-      init(c.info, c.main, circuit.main, targetType))
-    // writer.close
-    new WCircuit(circuit.info, modules, circuit.main, sim.io)
+
+    val transforms = Seq(new PreLinkRenaming(Namespace(innerCircuit)))
+    val outerState = new LowFirrtlCompiler().compile(CircuitState(chirrtl, ChirrtlForm, annos),
+                                                     transforms)
+
+    val outerCircuit = outerState.circuit
+    val targetType = module_type((innerCircuit.modules find (_.name == innerCircuit.main)).get)
+    val modules = innerCircuit.modules ++ (outerCircuit.modules flatMap
+      init(innerCircuit.info, innerCircuit.main, outerCircuit.main, targetType))
+
+    // Rename the annotations from the inner module, which are using an obsolete CircuitName
+    val renameMap = RenameMap(
+      Map(CircuitName(innerCircuit.main) -> Seq(CircuitName(outerCircuit.main))))
+
+    CircuitState(
+      circuit     = new WCircuit(outerCircuit.info, modules, outerCircuit.main, sim.io),
+      form        = HighForm,
+      annotations = innerState.annotations ++ outerState.annotations,
+      renames     = Some(renameMap)
+    )
   }
 }

--- a/src/main/scala/midas/passes/Utils.scala
+++ b/src/main/scala/midas/passes/Utils.scala
@@ -66,6 +66,13 @@ object Utils {
     }
     c copy (modules = modules map (_ map updateModNames), main = nameMap(c.main))
   }
+
+  // Takes a circuitState that has been emitted and writes the result to file
+  def writeEmittedCircuit(state: CircuitState, file: File) {
+    val f = new FileWriter(file)
+    f.write(state.getEmittedCircuit.value)
+    f.close
+  }
 }
 
 case class MemConf(

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -79,9 +79,11 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
   when (iTokensAvailable =/= UInt(0) && fromHostReady) {
     iTokensAvailable := iTokensAvailable - UInt(1)
   }
+
   when (oTokensPending =/= UInt(0) && toHostValid) {
     oTokensPending := oTokensPending - UInt(1)
   }
+
 
   when (io.step.fire) {
     iTokensAvailable := io.step.bits

--- a/src/main/verilog/emul_f1.v
+++ b/src/main/verilog/emul_f1.v
@@ -107,7 +107,7 @@ module emul;
 
   always #(`CLOCK_PERIOD / 2.0) clock = ~clock;
 
-  reg [1023:0] vcdplusfile = 0;
+  reg [2047:0] vcdplusfile = 0;
 
   initial begin
 `ifdef DEBUG

--- a/src/main/verilog/emul_f1.v
+++ b/src/main/verilog/emul_f1.v
@@ -108,18 +108,19 @@ module emul;
   always #(`CLOCK_PERIOD / 2.0) clock = ~clock;
 
   reg [2047:0] vcdplusfile = 0;
+  reg [63:0] dump_start = 0;
+  reg [63:0] trace_count = 0;
 
   initial begin
 `ifdef DEBUG
     if ($value$plusargs("waveform=%s", vcdplusfile))
     begin
+      $value$plusargs("dump-start=%d", dump_start);
       $vcdplusfile(vcdplusfile);
-      $vcdpluson(0);
-      $vcdplusmemon(0);
     end
 `endif
   end
-  
+
   reg                        master_ar_valid;
   wire                       master_ar_ready;
   reg  [`CTRL_ADDR_BITS-1:0] master_ar_addr;
@@ -510,11 +511,16 @@ module emul;
   );
 
   always @(posedge clock) begin
-    if (fin) begin
 `ifdef DEBUG
+    if (fin) begin
       $vcdplusclose;
-`endif
     end
+    if (trace_count == dump_start) begin
+      $vcdpluson(0);
+      $vcdplusmemon(0);
+    end
+`endif
+    trace_count = trace_count + 1;
     tick(
       reset,
       fin,

--- a/src/main/verilog/emul_zynq.v
+++ b/src/main/verilog/emul_zynq.v
@@ -79,6 +79,8 @@ module emul;
 
   reg [2047:0] vcdplusfile = 0;
   reg [63:0] dump_start = 0;
+  reg [63:0] dump_end = {64{1'b1}};
+  reg [63:0] dump_cycles = 0;
   reg [63:0] trace_count = 0;
 
   initial begin
@@ -86,7 +88,18 @@ module emul;
     if ($value$plusargs("waveform=%s", vcdplusfile))
     begin
       $value$plusargs("dump-start=%d", dump_start);
+      if ($value$plusargs("dump-cycles=%d", dump_cycles)) begin
+        dump_end = dump_start + dump_cycles;
+      end
+
       $vcdplusfile(vcdplusfile);
+      wait (trace_count >= dump_start) begin
+        $vcdpluson(0);
+        $vcdplusmemon(0);
+      end
+      wait ((trace_count > dump_end) || fin) begin
+        $vcdplusclose;
+      end
     end
 `endif
   end
@@ -353,15 +366,6 @@ module emul;
   );
 
   always @(posedge clock) begin
-`ifdef DEBUG
-    if (fin) begin
-      $vcdplusclose;
-    end
-    if (trace_count == dump_start) begin
-      $vcdpluson(0);
-      $vcdplusmemon(0);
-    end
-`endif
     trace_count = trace_count + 1;
     tick(
       reset,

--- a/src/main/verilog/emul_zynq.v
+++ b/src/main/verilog/emul_zynq.v
@@ -78,18 +78,19 @@ module emul;
   always #(`CLOCK_PERIOD / 2.0) clock = ~clock;
 
   reg [2047:0] vcdplusfile = 0;
+  reg [63:0] dump_start = 0;
+  reg [63:0] trace_count = 0;
 
   initial begin
 `ifdef DEBUG
     if ($value$plusargs("waveform=%s", vcdplusfile))
     begin
+      $value$plusargs("dump-start=%d", dump_start);
       $vcdplusfile(vcdplusfile);
-      $vcdpluson(0);
-      $vcdplusmemon(0);
     end
 `endif
   end
-  
+
   reg                        master_ar_valid;
   wire                       master_ar_ready;
   reg  [`CTRL_ADDR_BITS-1:0] master_ar_addr;
@@ -352,11 +353,16 @@ module emul;
   );
 
   always @(posedge clock) begin
-    if (fin) begin
 `ifdef DEBUG
+    if (fin) begin
       $vcdplusclose;
-`endif
     end
+    if (trace_count == dump_start) begin
+      $vcdpluson(0);
+      $vcdplusmemon(0);
+    end
+`endif
+    trace_count = trace_count + 1;
     tick(
       reset,
       fin,

--- a/src/main/verilog/emul_zynq.v
+++ b/src/main/verilog/emul_zynq.v
@@ -77,7 +77,7 @@ module emul;
 
   always #(`CLOCK_PERIOD / 2.0) clock = ~clock;
 
-  reg [1023:0] vcdplusfile = 0;
+  reg [2047:0] vcdplusfile = 0;
 
   initial begin
 `ifdef DEBUG


### PR DESCRIPTION
Paired with (firesim/firesim#108)

# MIDAS 0.3.2 Release

## General Notes:
- Moving forward, MIDAS branches will mirror FireSim branches with firesim/{master, dev} pointing at midas/{master,dev}
- MIDAS version updates will be released alongside FireSim releases 

## New Features:
- Firrtl annotations will now propogate through the MIDAS compiler
  - This allows annotations generated in SimMapping, PlaformMapping or in the target's generator to be consumed by a single downstream pass. 
- Custom transformations can now be registered and run after the MIDAS transformations.
- Added plusargs (+dump-start, +dump-cycles) to control VPD generation in MIDAS-level simulation (#83, #84)

## Bug Fixes 
- Fixed an AXI4 reordering bug in the ML-simulation shims (#81)
- Fixed a bug where the VPD file name would be truncated when dumping waves (#80)
