### PR TITLE
MIDAS support for firesim #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,19 @@ class MyZynqConfig extends Config(new WithMyEndpoints ++ new midas.ZynqConfig)
 To write endpoint software, implement a derived class of [`endpoint_t`](src/main/cc/endpoints/endpoint.h). Software models can be also plugged using this class. You are supposed to implement two methods.
 
 * `tick`: performs operations on outstanding transactions. This method may interact with software components.
-* `done`: informs whether or not all timing tokens from the target designs are consumed.
+* `terminate`: indicates that the endpoint is calling for simulation to terminate.
 
-Therefore, in the software driver, non-blocking `n` steps are taken with `step(n, false)`, and `tick` functions of all endpoints are called until they are `done`.
+Therefore, in the software driver, non-blocking `n` steps are taken with
+`step(n, false)`, and `tick` functions of all endpoints should be called until
+simif::done() returns true (the simulator has advanced n cycles) or one of the endpoints
+has signaled that the simulation should teriminate.
 
-`tick` and `done` are implemented using `read` and `write` functions for memory-mapped registers. Once custom endpoints are instantiated, macros for memory mapped registers are generated in `<Design>-const.h`. If you implemented an endpoint widget `FooWidget` and generated a memory mapped register with `name` being `"bar"`, this register can be read and written with `read(FOOWIDGET_0(bar))` and `write(FOOWIDGET_0(bar), ...)`, respectively.
+`tick` is implemented using `read` and `write` functions for memory-mapped
+registers. Once custom endpoints are instantiated, macros for memory mapped
+registers are generated in `<Design>-const.h`. If you implemented an endpoint
+widget `FooWidget` and generated a memory mapped register with `name` being
+`"bar"`, this register can be read and written with `read(FOOWIDGET_0(bar))`
+and `write(FOOWIDGET_0(bar), ...)`, respectively.
 
 ### Porting to Other FPGA Platforms
 

--- a/README.md
+++ b/README.md
@@ -299,11 +299,12 @@ To write endpoint software, implement a derived class of [`endpoint_t`](src/main
 
 * `tick`: performs operations on outstanding transactions. This method may interact with software components.
 * `terminate`: indicates that the endpoint is calling for simulation to terminate.
+* `exit_code`: indicates what caused the endpoint to signal for termination.
 
 Therefore, in the software driver, non-blocking `n` steps are taken with
 `step(n, false)`, and `tick` functions of all endpoints should be called until
 simif::done() returns true (the simulator has advanced n cycles) or one of the endpoints
-has signaled that the simulation should teriminate.
+has signaled that the simulation should terminate.
 
 `tick` is implemented using `read` and `write` functions for memory-mapped
 registers. Once custom endpoints are instantiated, macros for memory mapped

--- a/src/main/cc/endpoints/endpoint.h
+++ b/src/main/cc/endpoints/endpoint.h
@@ -19,7 +19,7 @@ public:
   virtual void tick() = 0;
   // Indicates the simulation should terminate.
   // Tie off to false if the endpoint will never call for the simulation to teriminate.
-  virtual bool done() = 0;
+  virtual bool terminate() = 0;
 
 protected:
   void write(size_t addr, data_t data) {

--- a/src/main/cc/endpoints/endpoint.h
+++ b/src/main/cc/endpoints/endpoint.h
@@ -5,28 +5,36 @@
 
 #include "simif.h"
 
+// Endpoints are widgets that are directly exposed to simulation timing (they
+// produce and/or consume simulation tokens). They must be tick()-ed for the
+// simulation to make forward progress.
+
 class endpoint_t
 {
 public:
   endpoint_t(simif_t* s): sim(s) { }
-  virtual void init() {}; // FIXME; should be pure;
+  // Initialize FPGA-hosted endpoint state -- this can't be done in the constructor
+  virtual void init() = 0;
+  // Does work that allows the endpoint to advance in simulation time (one or more cycles)
   virtual void tick() = 0;
+  // Indicates the simulation should terminate.
+  // Tie off to false if the endpoint will never call for the simulation to teriminate.
   virtual bool done() = 0;
 
 protected:
-  inline void write(size_t addr, data_t data) {
+  void write(size_t addr, data_t data) {
     sim->write(addr, data);
   }
-  
-  inline data_t read(size_t addr) {
+
+  data_t read(size_t addr) {
     return sim->read(addr);
   }
 
-  inline ssize_t pull(size_t addr, char *data, size_t size) {
+  ssize_t pull(size_t addr, char *data, size_t size) {
     return sim->pull(addr, data, size);
   }
 
-  inline ssize_t push(size_t addr, char *data, size_t size) {
+  ssize_t push(size_t addr, char *data, size_t size) {
     if (size == 0)
       return 0;
     return sim->push(addr, data, size);

--- a/src/main/cc/endpoints/endpoint.h
+++ b/src/main/cc/endpoints/endpoint.h
@@ -20,6 +20,9 @@ public:
   // Indicates the simulation should terminate.
   // Tie off to false if the endpoint will never call for the simulation to teriminate.
   virtual bool terminate() = 0;
+  // If the endpoint calls for termination, encode a cause here. 0 = PASS All other
+  // codes are endpoint-implementation defined
+  virtual int exit_code() = 0;
 
 protected:
   void write(size_t addr, data_t data) {

--- a/src/main/cc/endpoints/sim_mem.cc
+++ b/src/main/cc/endpoints/sim_mem.cc
@@ -48,14 +48,6 @@ bool sim_mem_t::stall() {
 #endif
 }
 
-bool sim_mem_t::done() {
-#ifdef NASTIWIDGET_0
-  return read(NASTIWIDGET_0(done));
-#else
-  return true;
-#endif
-}
-
 const uint64_t addr_mask = (1L << MEM_ADDR_BITS) - 1;
 const data_t id_mask = (1 << MEM_ID_BITS) - 1;
 const data_t size_mask = (1 << MEM_SIZE_BITS) - 1;
@@ -138,6 +130,8 @@ void sim_mem_t::send(sim_mem_data_t& data) {
 
 void sim_mem_t::tick() {
 #ifdef NASTIWIDGET_0
+  if (read(NASTIWIDGET_0(done))) return;
+
   bool _stall = this->stall();
   static size_t num_reads = 0;
   static size_t num_writes = 0;

--- a/src/main/cc/endpoints/sim_mem.h
+++ b/src/main/cc/endpoints/sim_mem.h
@@ -57,6 +57,7 @@ public:
 
   virtual void tick();
   virtual bool terminate() { return false; };
+  virtual int exit_code() { return 0; };
 
   void write_mem(uint64_t addr, void* data);
 

--- a/src/main/cc/endpoints/sim_mem.h
+++ b/src/main/cc/endpoints/sim_mem.h
@@ -56,7 +56,7 @@ public:
   void recv(sim_mem_data_t& data);
 
   virtual void tick();
-  virtual bool done();
+  virtual bool terminate() { return false; };
 
   void write_mem(uint64_t addr, void* data);
 

--- a/src/main/cc/simif.cc
+++ b/src/main/cc/simif.cc
@@ -61,6 +61,13 @@ uint64_t simif_t::actual_tcycle() {
     return (((uint64_t) cycle_h) << 32) | cycle_l;
 }
 
+uint64_t simif_t::hcycle() {
+    write(DEFAULTIOWIDGET(hCycle_latch), 1);
+    data_t cycle_l = read(DEFAULTIOWIDGET(hCycle_0));
+    data_t cycle_h = read(DEFAULTIOWIDGET(hCycle_1));
+    return (((uint64_t) cycle_h) << 32) | cycle_l;
+}
+
 void simif_t::target_reset(int pulse_start, int pulse_length) {
   poke(reset, 0);
   take_steps(pulse_start, true);

--- a/src/main/cc/simif.cc
+++ b/src/main/cc/simif.cc
@@ -80,7 +80,7 @@ int simif_t::finish() {
   finish_sampling();
 #endif
 
-  fprintf(stderr, "Runs %llu cycles\n", cycles());
+  fprintf(stderr, "Runs %llu cycles\n", actual_tcycle());
   fprintf(stderr, "[%s] %s Test", pass ? "PASS" : "FAIL", TARGET_NAME);
   if (!pass) { fprintf(stdout, " at cycle %llu", fail_t); }
   fprintf(stderr, "\nSEED: %ld\n", seed);
@@ -134,9 +134,8 @@ bool simif_t::expect(size_t id, mpz_t& expected) {
   return expect(pass, NULL);
 }
 
-void simif_t::step(int n, bool blocking) {
+void simif_t::step(uint32_t n, bool blocking) {
   if (n == 0) return;
-  assert(n > 0);
 #ifdef ENABLE_SNAPSHOT
   reservoir_sampling(n);
 #endif

--- a/src/main/cc/simif.cc
+++ b/src/main/cc/simif.cc
@@ -54,6 +54,13 @@ void simif_t::init(int argc, char** argv, bool log) {
 #endif
 }
 
+uint64_t simif_t::actual_tcycle() {
+    write(DEFAULTIOWIDGET(tCycle_latch), 1);
+    data_t cycle_l = read(DEFAULTIOWIDGET(tCycle_0));
+    data_t cycle_h = read(DEFAULTIOWIDGET(tCycle_1));
+    return (((uint64_t) cycle_h) << 32) | cycle_l;
+}
+
 void simif_t::target_reset(int pulse_start, int pulse_length) {
   poke(reset, 0);
   take_steps(pulse_start, true);

--- a/src/main/cc/simif.h
+++ b/src/main/cc/simif.h
@@ -105,9 +105,11 @@ class simif_t
     // Returns an upper bound for the cycle reached by the target
     // If using blocking steps, this will be ~equivalent to actual_tcycle()
     uint64_t cycles(){ return t; };
-    // Returns the current cycle as measured by a hardware counter in the DefaultIOWidget
+    // Returns the current target cycle as measured by a hardware counter in the DefaultIOWidget
     // (# of reset tokens generated)
     uint64_t actual_tcycle();
+    // Returns the current host cycle as measured by a hardware counter
+    uint64_t hcycle();
     uint64_t rand_next(uint64_t limit) { return gen() % limit; }
 
 #ifdef ENABLE_SNAPSHOT

--- a/src/main/cc/simif.h
+++ b/src/main/cc/simif.h
@@ -51,7 +51,7 @@ class simif_t
     // Simulation APIs
     virtual void init(int argc, char** argv, bool log = false);
     virtual int finish();
-    virtual void step(int n, bool blocking = true);
+    virtual void step(uint32_t n, bool blocking = true);
     inline bool done() { return read(MASTER(DONE)); }
 
     // Widget communication

--- a/src/main/cc/simif.h
+++ b/src/main/cc/simif.h
@@ -102,7 +102,12 @@ class simif_t
     // A default reset scheme that pulses the global chisel reset
     void target_reset(int pulse_start = 1, int pulse_length = 5);
 
-    inline uint64_t cycles() { return t; }
+    // Returns an upper bound for the cycle reached by the target
+    // If using blocking steps, this will be ~equivalent to actual_tcycle()
+    uint64_t cycles(){ return t; };
+    // Returns the current cycle as measured by a hardware counter in the DefaultIOWidget
+    // (# of reset tokens generated)
+    uint64_t actual_tcycle();
     uint64_t rand_next(uint64_t limit) { return gen() % limit; }
 
 #ifdef ENABLE_SNAPSHOT

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -51,6 +51,8 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
   val oTokensPending = RegInit(1.U(io.ctrl.nastiXDataBits.W))
   val tCycleName = "tCycle"
   val tCycle = genWideRORegInit(0.U(64.W), tCycleName)
+  val hCycleName = "hCycle"
+  val hCycle = genWideRORegInit(0.U(64.W), hCycleName)
 
   // needs back pressure from reset queues
   val fromHostReady = io.ins.foldLeft(io.tReset.ready)(_ && _.ready)
@@ -86,6 +88,7 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
     oTokensPending := oTokensPending - UInt(1)
     tCycle := tCycle + 1.U
   }
+  hCycle := hCycle + 1.U
 
 
   when (io.step.fire) {


### PR DESCRIPTION
Changes:
- Adds hardware host- and target-cycle counters
  - This is critical for measuring target time accurately when taking large non-blocking steps
- Reworks endpoint_t interface
  - With one exception all existing endpoints use tick() to model multiple target cycles or to execute a functional model, reflect that in the docs
  - Change done -> terminate, which indicates the endpoint wants to tear down simulation
  - Adds exit_code(), to indicate a termination cause
    - These wrap fesvr::done() and fesvr::exit_code() naturally


