### PR TITLE
auto-generate DMA address map

### DIFF
--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -133,7 +133,8 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
     arb.io.master(memIoSize) <> loadMem.io.toSlaveMem
   }
 
-  val dmaInfoBuffer = new ListBuffer[(String, NastiIO, BigInt)]
+  case class DmaInfo(name: String, port: NastiIO, size: BigInt)
+  val dmaInfoBuffer = new ListBuffer[DmaInfo]
 
   // Instantiate endpoint widgets
   defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft true.B) { (resetReady, endpoint) =>
@@ -159,7 +160,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
       channels2Port(widget.io.hPort, endpoint(i)._2)
 
       if (widget.io.dma.nonEmpty)
-        dmaInfoBuffer += Tuple3(widgetName, widget.io.dma.get, widget.io.dmaSize)
+        dmaInfoBuffer += DmaInfo(widgetName, widget.io.dma.get, widget.io.dmaSize)
 
       // each widget should have its own reset queue
       val resetQueue = Module(new WireChannel(1, endpoint.clockRatio))
@@ -174,18 +175,18 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
   }
 
   // Sort the list of DMA ports by address region size, largest to smallest
-  val dmaInfoSorted = dmaInfoBuffer.sortBy(_._3).reverse.toSeq
+  val dmaInfoSorted = dmaInfoBuffer.sortBy(_.size).reverse.toSeq
   // Build up the address map using the sorted list,
   // auto-assigning base addresses as we go.
   val dmaAddrMap = dmaInfoSorted.foldLeft((BigInt(0), List.empty[AddrMapEntry])) {
-    case ((startAddr, addrMap), (widgetName, _, reqSize)) =>
+    case ((startAddr, addrMap), DmaInfo(widgetName, _, reqSize)) =>
       // Round up the size to the nearest power of 2
       val regionSize = 1 << log2Ceil(reqSize)
       val region = MemRange(startAddr, regionSize, MemAttr(AddrMapProt.RW))
 
       (startAddr + regionSize, AddrMapEntry(widgetName, region) :: addrMap)
   }._2.reverse
-  val dmaPorts = dmaInfoSorted.map(_._2)
+  val dmaPorts = dmaInfoSorted.map(_.port)
 
   if (dmaPorts.isEmpty) {
     val dmaParams = p.alterPartial({ case NastiKey => p(DMANastiKey) })

--- a/src/main/scala/midas/passes/PlatformMapping.scala
+++ b/src/main/scala/midas/passes/PlatformMapping.scala
@@ -20,7 +20,7 @@ private[passes] class PlatformMapping(
   override def name = "[MIDAS] Platform Mapping"
 
   private def dumpHeader(c: platform.PlatformShim) {
-    def vMacro(arg: (String, Int)): String = s"`define ${arg._1} ${arg._2}\n"
+    def vMacro(arg: (String, Long)): String = s"`define ${arg._1} ${arg._2}L\n"
 
     val csb = new StringBuilder
     csb append "#ifndef __%s_H\n".format(target.toUpperCase)

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -19,7 +19,7 @@ class F1Shim(simIo: midas.core.SimWrapperIO)
               (implicit p: Parameters) extends PlatformShim {
   val io = IO(new F1ShimIO)
   val top = Module(new midas.core.FPGATop(simIo))
-  val headerConsts = List(
+  val headerConsts = List[(String, Long)](
     "MMIO_WIDTH" -> p(MasterNastiKey).dataBits / 8,
     "MEM_WIDTH"  -> p(SlaveNastiKey).dataBits / 8,
     "DMA_WIDTH"  -> p(DMANastiKey).dataBits / 8

--- a/src/main/scala/midas/platform/ZynqShim.scala
+++ b/src/main/scala/midas/platform/ZynqShim.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.util.ParameterizedBundle
 
 abstract class PlatformShim(implicit p: Parameters) extends Module {
   def top: midas.core.FPGATop
-  def headerConsts: Seq[(String, Int)]
+  def headerConsts: Seq[(String, Long)]
   def genHeader(sb: StringBuilder, target: String) {
     import widgets.CppGenerationUtils._
     sb.append(genStatic("TARGET_NAME", widgets.CStrLit(target)))
@@ -40,7 +40,7 @@ class ZynqShim(simIo: midas.core.SimWrapperIO)
               (implicit p: Parameters) extends PlatformShim {
   val io = IO(new ZynqShimIO)
   val top = Module(new midas.core.FPGATop(simIo))
-  val headerConsts = List(
+  val headerConsts = List[(String, Long)](
     "MMIO_WIDTH" -> p(MasterNastiKey).dataBits / 8,
     "MEM_WIDTH"  -> p(SlaveNastiKey).dataBits / 8
   ) ++ top.headerConsts

--- a/src/main/scala/midas/widgets/Assert.scala
+++ b/src/main/scala/midas/widgets/Assert.scala
@@ -28,8 +28,6 @@ object AssertBundle {
 
 class AssertWidgetIO(val numAsserts: Int)(implicit p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(new AssertBundle(numAsserts)))
-  val dma = None
-  val address = None // DMA unused
 }
 
 class AssertBundleEndpoint extends Endpoint {

--- a/src/main/scala/midas/widgets/NastiIO.scala
+++ b/src/main/scala/midas/widgets/NastiIO.scala
@@ -14,6 +14,9 @@ import freechips.rocketchip.diplomacy.AddressSet
 abstract class EndpointWidgetIO(implicit p: Parameters) extends WidgetIO()(p) {
   def hPort: HostPortIO[Data] // Tokenized port moving between the endpoint the target-RTL
   val dma: Option[NastiIO] = None
+  // Specify the size that you want the address region to be in the DMA memory map
+  // For proper functioning, the region should be at least as big as the
+  // largest read/write request you plan to send over PCIS
   val dmaSize: BigInt = BigInt(0)
   val tReset = Flipped(Decoupled(Bool()))
 }

--- a/src/main/scala/midas/widgets/NastiIO.scala
+++ b/src/main/scala/midas/widgets/NastiIO.scala
@@ -13,8 +13,8 @@ import freechips.rocketchip.diplomacy.AddressSet
 
 abstract class EndpointWidgetIO(implicit p: Parameters) extends WidgetIO()(p) {
   def hPort: HostPortIO[Data] // Tokenized port moving between the endpoint the target-RTL
-  def dma: Option[NastiIO]
-  def address: Option[AddressSet]
+  val dma: Option[NastiIO] = None
+  val dmaSize: BigInt = BigInt(0)
   val tReset = Flipped(Decoupled(Bool()))
 }
 
@@ -29,8 +29,6 @@ class MemModelIO(implicit val p: Parameters) extends EndpointWidgetIO()(p){
   val tNasti = Flipped(HostPort(new NastiIO, false))
   val host_mem = new NastiIO()(p.alterPartial({ case NastiKey => p(MemNastiKey)}))
   def hPort = tNasti
-  val dma = None
-  val address = None
 }
 
 abstract class MemModel(implicit p: Parameters) extends EndpointWidget()(p){

--- a/src/main/scala/midas/widgets/Print.scala
+++ b/src/main/scala/midas/widgets/Print.scala
@@ -55,16 +55,12 @@ class PrintRecordEndpoint extends Endpoint {
 
 class PrintWidgetIO(private val record: PrintRecord)(implicit p: Parameters) extends EndpointWidgetIO()(p) {
   val hPort = Flipped(HostPort(record))
-  val dma = if (p(HasDMAChannel)) {
+  override val dma = if (p(HasDMAChannel)) {
     Some(Flipped(new NastiIO()( p.alterPartial({ case NastiKey => p(DMANastiKey) }))))
-  } else {
-    None
-  }
-  val address = if (p(HasDMAChannel)) {
+  } else None
+  override val dmaSize = if (p(HasDMAChannel)) {
     throw new RuntimeException("Damn it Howie.")
-  } else {
-    None
-  }
+  } else BigInt(0)
 }
 
 class PrintWidget(printRecord: PrintRecord)(implicit p: Parameters) extends EndpointWidget()(p) with HasChannels {


### PR DESCRIPTION
This switches the PCIS DMA interface from using hard-coded addresses to auto-generated ones. The endpoint writer now needs only to specify the size of the address region it wants and the base addresses will be automatically assigned. A macro for the base address will be output to the const header file for use by the C++ code.

The size specified for the endpoint should be the size of the largest single burst that the host C++ driver will request.