### PR TITLE
Fix myriad Chisel deprecation & scala warnings

### DIFF
--- a/src/main/scala/junctions/MultiWidthFifo.scala
+++ b/src/main/scala/junctions/MultiWidthFifo.scala
@@ -83,12 +83,12 @@ class MultiWidthFifoTest extends UnitTest {
   val big2little = Module(new MultiWidthFifo(16, 8, 8))
   val little2big = Module(new MultiWidthFifo(8, 16, 4))
 
-  val bl_send = Reg(init = Bool(false))
-  val lb_send = Reg(init = Bool(false))
-  val bl_recv = Reg(init = Bool(false))
-  val lb_recv = Reg(init = Bool(false))
-  val bl_finished = Reg(init = Bool(false))
-  val lb_finished = Reg(init = Bool(false))
+  val bl_send = Reg(init = false.B)
+  val lb_send = Reg(init = false.B)
+  val bl_recv = Reg(init = false.B)
+  val lb_recv = Reg(init = false.B)
+  val bl_finished = Reg(init = false.B)
+  val lb_finished = Reg(init = false.B)
 
   val bl_data = Vec.tabulate(4){i => UInt((2 * i + 1) * 256 + 2 * i, 16)}
   val lb_data = Vec.tabulate(8){i => UInt(i, 8)}
@@ -117,28 +117,28 @@ class MultiWidthFifoTest extends UnitTest {
     lb_data(Cat(lb_recv_cnt, UInt(0, 1))))
 
   when (io.start) {
-    bl_send := Bool(true)
-    lb_send := Bool(true)
+    bl_send := true.B
+    lb_send := true.B
   }
 
   when (bl_send_done) {
-    bl_send := Bool(false)
-    bl_recv := Bool(true)
+    bl_send := false.B
+    bl_recv := true.B
   }
 
   when (lb_send_done) {
-    lb_send := Bool(false)
-    lb_recv := Bool(true)
+    lb_send := false.B
+    lb_recv := true.B
   }
 
   when (bl_recv_done) {
-    bl_recv := Bool(false)
-    bl_finished := Bool(true)
+    bl_recv := false.B
+    bl_finished := true.B
   }
 
   when (lb_recv_done) {
-    lb_recv := Bool(false)
-    lb_finished := Bool(true)
+    lb_recv := false.B
+    lb_finished := true.B
   }
 
   io.finished := bl_finished && lb_finished

--- a/src/main/scala/junctions/addrmap.scala
+++ b/src/main/scala/junctions/addrmap.scala
@@ -127,11 +127,11 @@ class AddrMap(
   def isCacheable(addr: UInt): Bool = {
     flatten.filter(_.region.attr.cacheable).map(
       _.region.containsAddress(addr)
-    ).foldLeft(Bool(false))(_ || _)
+    ).foldLeft(false.B)(_ || _)
   }
 
   def isValid(addr: UInt): Bool = {
-    flatten.map(_.region.containsAddress(addr)).foldLeft(Bool(false))(_ || _)
+    flatten.map(_.region.containsAddress(addr)).foldLeft(false.B)(_ || _)
   }
 
   def getProt(addr: UInt): AddrMapProt = {

--- a/src/main/scala/junctions/nasti.scala
+++ b/src/main/scala/junctions/nasti.scala
@@ -161,7 +161,7 @@ object NastiWriteAddressChannel {
     aw.len := len
     aw.size := size
     aw.burst := burst
-    aw.lock := Bool(false)
+    aw.lock := false.B
     aw.cache := CACHE_DEVICE_NOBUF
     aw.prot := AXPROT(false, false, false)
     aw.qos := UInt("b0000")
@@ -181,7 +181,7 @@ object NastiReadAddressChannel {
     ar.len := len
     ar.size := size
     ar.burst := burst
-    ar.lock := Bool(false)
+    ar.lock := false.B
     ar.cache := CACHE_DEVICE_NOBUF
     ar.prot := AXPROT(false, false, false)
     ar.qos := UInt(0)
@@ -193,7 +193,7 @@ object NastiReadAddressChannel {
 
 object NastiWriteDataChannel {
   def apply(data: UInt, strb: Option[UInt] = None,
-            last: Bool = Bool(true), id: UInt = UInt(0))
+            last: Bool = true.B, id: UInt = UInt(0))
            (implicit p: Parameters): NastiWriteDataChannel = {
     val w = Wire(new NastiWriteDataChannel)
     w.strb := strb.getOrElse(Fill(w.nastiWStrobeBits, UInt(1, 1)))
@@ -206,7 +206,7 @@ object NastiWriteDataChannel {
 }
 
 object NastiReadDataChannel {
-  def apply(id: UInt, data: UInt, last: Bool = Bool(true), resp: UInt = UInt(0))(
+  def apply(id: UInt, data: UInt, last: Bool = true.B, resp: UInt = UInt(0))(
       implicit p: Parameters) = {
     val r = Wire(new NastiReadDataChannel)
     r.id := id
@@ -267,15 +267,15 @@ class NastiArbiter(val arbN: Int)(implicit p: Parameters) extends NastiModule {
     val aw_arb = Module(new RRArbiter(new NastiWriteAddressChannel, arbN))
 
     val w_chosen = Reg(UInt(width = arbIdBits))
-    val w_done = Reg(init = Bool(true))
+    val w_done = Reg(init = true.B)
 
     when (aw_arb.io.out.fire()) {
       w_chosen := aw_arb.io.chosen
-      w_done := Bool(false)
+      w_done := false.B
     }
 
     when (io.slave.w.fire() && io.slave.w.bits.last) {
-      w_done := Bool(true)
+      w_done := true.B
     }
 
     val queueSize = min((1 << nastiXIdBits) * arbN, 64)
@@ -360,11 +360,11 @@ class NastiErrorSlave(implicit p: Parameters) extends NastiModule {
   val r_queue = Module(new Queue(new NastiReadAddressChannel, 1))
   r_queue.io.enq <> io.ar
 
-  val responding = Reg(init = Bool(false))
+  val responding = Reg(init = false.B)
   val beats_left = Reg(init = UInt(0, nastiXLenBits))
 
   when (!responding && r_queue.io.deq.valid) {
-    responding := Bool(true)
+    responding := true.B
     beats_left := r_queue.io.deq.bits.len
   }
 
@@ -378,17 +378,17 @@ class NastiErrorSlave(implicit p: Parameters) extends NastiModule {
 
   when (io.r.fire()) {
     when (beats_left === UInt(0)) {
-      responding := Bool(false)
+      responding := false.B
     } .otherwise {
       beats_left := beats_left - UInt(1)
     }
   }
 
-  val draining = Reg(init = Bool(false))
+  val draining = Reg(init = false.B)
   io.w.ready := draining
 
-  when (io.aw.fire()) { draining := Bool(true) }
-  when (io.w.fire() && io.w.bits.last) { draining := Bool(false) }
+  when (io.aw.fire()) { draining := true.B }
+  when (io.w.fire() && io.w.bits.last) { draining := false.B }
 
   val b_queue = Module(new Queue(UInt(width = nastiWIdBits), 1))
   b_queue.io.enq.valid := io.aw.valid && !draining
@@ -419,9 +419,9 @@ class NastiRouter(nSlaves: Int, routeSel: UInt => UInt)(implicit p: Parameters)
   val ar_route = routeSel(io.master.ar.bits.addr)
   val aw_route = routeSel(io.master.aw.bits.addr)
 
-  val ar_ready = Wire(init = Bool(false))
-  val aw_ready = Wire(init = Bool(false))
-  val w_ready = Wire(init = Bool(false))
+  val ar_ready = Wire(init = false.B)
+  val aw_ready = Wire(init = false.B)
+  val w_ready = Wire(init = false.B)
 
   val queueSize = min((1 << nastiXIdBits) * nSlaves, 64)
 

--- a/src/main/scala/midas/core/Channel.scala
+++ b/src/main/scala/midas/core/Channel.scala
@@ -92,7 +92,7 @@ class WireChannel(
     io.trace <> TraceQueue(tokens.io.deq, io.traceLen)
   } else {
     io.trace := DontCare
-    io.trace.valid := Bool(false)
+    io.trace.valid := false.B
   }
 }
 
@@ -283,9 +283,9 @@ class ReadyValidChannel[T <: Data](
     io.trace.ready <> TraceQueue(wires.ready, io.traceLen, "ready_trace", Some(readyTraceFull))
   } else {
     io.trace := DontCare
-    io.trace.bits.valid  := Bool(false)
-    io.trace.valid.valid := Bool(false)
-    io.trace.ready.valid := Bool(false)
+    io.trace.bits.valid  := false.B
+    io.trace.valid.valid := false.B
+    io.trace.ready.valid := false.B
   }
 }
 

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -17,7 +17,7 @@ case object MemNastiKey extends Field[NastiParameters]
 case object DMANastiKey extends Field[NastiParameters]
 case object FpgaMMIOSize extends Field[BigInt]
 
-class FPGATopIO(implicit p: Parameters) extends WidgetIO {
+class FPGATopIO(implicit val p: Parameters) extends WidgetIO {
   val dma  = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
   val mem = new NastiIO()(p alterPartial ({ case NastiKey => p(MemNastiKey) }))
 }

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -104,7 +104,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
         case ActualDirection.Input =>
           val channels = simIo.getIns(wire)
           channels.zipWithIndex foreach { case (in, i) =>
-            in.bits  := target >> UInt(i * simIo.channelWidth)
+            in.bits  := target >> (i * simIo.channelWidth).U
             in.valid := port.fromHost.hValid || simResetNext
           }
           ready ++= channels map (_.ready)

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -136,7 +136,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
   val addresses = new ListBuffer[AddressSet]
 
   // Instantiate endpoint widgets
-  defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft Bool(true)){ (resetReady, endpoint) =>
+  defaultIOWidget.io.tReset.ready := (simIo.endpoints foldLeft true.B){ (resetReady, endpoint) =>
     ((0 until endpoint.size) foldLeft resetReady){ (ready, i) =>
       val widgetName = (endpoint, p(MemModelKey)) match {
         case (_: SimMemIO, Some(_)) => s"MemModel_$i"

--- a/src/main/scala/midas/core/FPGATop.scala
+++ b/src/main/scala/midas/core/FPGATop.scala
@@ -114,6 +114,7 @@ class FPGATop(simIoType: SimWrapperIO)(implicit p: Parameters) extends Module wi
           channels foreach (_.ready := port.toHost.hReady)
           valid ++= channels map (_.valid)
       }
+      case _ => throw new RuntimeException("Uexpected type tuple in channels2Port")
     }
 
     loop(port.hBits -> wires)

--- a/src/main/scala/midas/core/SimWrapper.scala
+++ b/src/main/scala/midas/core/SimWrapper.scala
@@ -373,7 +373,7 @@ class SimWrapper(targetIo: Seq[(String, Data)], generatedTargetIo: Seq[(String, 
   // Cycles for debug
   val cycles = Reg(UInt(64.W))
   when (fire) {
-    // cycles := Mux(target.io.reset, UInt(0), cycles + UInt(1))
+    // cycles := Mux(target.io.reset, 0.U, cycles + 1.U)
     when(false.B) { printf("%d", cycles) }
   }
 }

--- a/src/main/scala/midas/core/SimWrapper.scala
+++ b/src/main/scala/midas/core/SimWrapper.scala
@@ -199,7 +199,9 @@ class SimWrapperIO(io: TargetBoxIO)
 }
 
 class TargetBoxIO(targetIo: Seq[(String, Data)]) extends Record {
-  val elements = ListMap((targetIo map { case (name, field) => name -> chiselTypeOf(field)}):_*)
+  // ChiselTypeOf is more strict; rely on chiselCloneType behavior defaulting
+  // to output for pass-added target-IO for now
+  val elements = ListMap((targetIo map { case (name, field) => name -> field.chiselCloneType}):_*)
   def resets = elements collect { case (_, r: Reset) => r }
   def clocks = elements collect { case (_, c: Clock) => c }
   def cloneType = new TargetBoxIO(targetIo).asInstanceOf[this.type]

--- a/src/main/scala/midas/core/SimWrapper.scala
+++ b/src/main/scala/midas/core/SimWrapper.scala
@@ -199,7 +199,7 @@ class SimWrapperIO(io: TargetBoxIO)
 }
 
 class TargetBoxIO(targetIo: Seq[(String, Data)]) extends Record {
-  val elements = ListMap((targetIo map { case (name, field) => name -> field.chiselCloneType }):_*)
+  val elements = ListMap((targetIo map { case (name, field) => name -> chiselTypeOf(field)}):_*)
   def resets = elements collect { case (_, r: Reset) => r }
   def clocks = elements collect { case (_, c: Clock) => c }
   def cloneType = new TargetBoxIO(targetIo).asInstanceOf[this.type]

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -27,7 +27,7 @@ class F1Shim(simIo: midas.core.SimWrapperIO)
   ) ++ top.headerConsts
 
   val cyclecount = RegInit(UInt(0, width=64.W))
-  cyclecount := cyclecount + UInt(1)
+  cyclecount := cyclecount + 1.U
 
   if (p(AXIDebugPrint)) {
     // print all transactions

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -26,7 +26,7 @@ class F1Shim(simIo: midas.core.SimWrapperIO)
     "DMA_WIDTH"  -> p(DMANastiKey).dataBits / 8
   ) ++ top.headerConsts
 
-  val cyclecount = Reg(init = UInt(0, width=64.W))
+  val cyclecount = RegInit(UInt(0, width=64.W))
   cyclecount := cyclecount + UInt(1)
 
   if (p(AXIDebugPrint)) {

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -26,7 +26,7 @@ class F1Shim(simIo: midas.core.SimWrapperIO)
     "DMA_WIDTH"  -> p(DMANastiKey).dataBits / 8
   ) ++ top.headerConsts
 
-  val cyclecount = RegInit(UInt(0, width=64.W))
+  val cyclecount = RegInit(0.U(64.W))
   cyclecount := cyclecount + 1.U
 
   if (p(AXIDebugPrint)) {

--- a/src/main/scala/midas/platform/F1Shim.scala
+++ b/src/main/scala/midas/platform/F1Shim.scala
@@ -5,12 +5,11 @@ import chisel3._
 import chisel3.util._
 import junctions._
 import freechips.rocketchip.config.{Parameters, Field}
-import freechips.rocketchip.util.ParameterizedBundle
 import midas.core.DMANastiKey
 
 case object AXIDebugPrint extends Field[Boolean]
 
-class F1ShimIO(implicit p: Parameters) extends ParameterizedBundle()(p) {
+class F1ShimIO(implicit val p: Parameters) extends Bundle {
   val master = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(MasterNastiKey) })))
   val dma    = Flipped(new NastiIO()(p alterPartial ({ case NastiKey => p(DMANastiKey) })))
   val slave  = new NastiIO()(p alterPartial ({ case NastiKey => p(SlaveNastiKey) }))

--- a/src/main/scala/midas/widgets/LoadMem.scala
+++ b/src/main/scala/midas/widgets/LoadMem.scala
@@ -11,7 +11,7 @@ import freechips.rocketchip.subsystem.{ExtMem, MasterPortParams}
 
 import scala.math.{max, min}
 
-class LoadMemIO(hKey: Field[NastiParameters])(implicit p: Parameters) extends WidgetIO()(p){
+class LoadMemIO(val hKey: Field[NastiParameters])(implicit val p: Parameters) extends WidgetIO()(p){
   // TODO: Slave nasti key should be passed in explicitly
   val toSlaveMem = new NastiIO()(p alterPartial ({ case NastiKey => p(hKey) }))
 }

--- a/src/main/scala/midas/widgets/LoadMem.scala
+++ b/src/main/scala/midas/widgets/LoadMem.scala
@@ -100,7 +100,7 @@ class LoadMemWidget(hKey: Field[NastiParameters], maxBurst: Int = 8)(implicit p:
 
   val cWidth = p(CtrlNastiKey).dataBits
   val hWidth = p(hKey).dataBits
-  val size = hParams.bytesToXSize(UInt(hWidth/8))
+  val size = hParams.bytesToXSize((hWidth/8).U)
   val widthRatio = hWidth/cWidth
   require(hWidth >= cWidth)
   require(p(hKey).addrBits <= 2 * cWidth)

--- a/src/main/scala/midas/widgets/Master.scala
+++ b/src/main/scala/midas/widgets/Master.scala
@@ -24,7 +24,7 @@ object Pulsify {
       when(in){count.inc()}
       when(count.value === UInt(pulseLength-1)) {
         in := false.B
-        count.value := UInt(0)
+        count.value := 0.U
       }
     } else {
       when(in) {in := false.B}
@@ -36,7 +36,7 @@ class EmulationMaster(implicit p: Parameters) extends Widget()(p) {
   val io = IO(new EmulationMasterIO)
   Pulsify(genWORegInit(io.simReset, "SIM_RESET", false.B), pulseLength = 4)
   genAndAttachQueue(io.step, "STEP")
-  genRORegInit(io.done && ~io.simReset, "DONE", UInt(0))
+  genRORegInit(io.done && ~io.simReset, "DONE", 0.U)
 
   genCRFile()
 

--- a/src/main/scala/midas/widgets/Master.scala
+++ b/src/main/scala/midas/widgets/Master.scala
@@ -10,7 +10,7 @@ import chisel3._
 import chisel3.util.{Decoupled, Counter, log2Up}
 import freechips.rocketchip.config.Parameters
 
-class EmulationMasterIO(implicit p: Parameters) extends WidgetIO()(p){
+class EmulationMasterIO(implicit val p: Parameters) extends WidgetIO()(p){
   val simReset = Output(Bool())
   val done = Input(Bool())
   val step = Decoupled(UInt(p(CtrlNastiKey).dataBits.W))

--- a/src/main/scala/midas/widgets/Master.scala
+++ b/src/main/scala/midas/widgets/Master.scala
@@ -22,7 +22,7 @@ object Pulsify {
     if (pulseLength > 1) {
       val count = Counter(pulseLength)
       when(in){count.inc()}
-      when(count.value === UInt(pulseLength-1)) {
+      when(count.value === (pulseLength - 1).U) {
         in := false.B
         count.value := 0.U
       }

--- a/src/main/scala/midas/widgets/Master.scala
+++ b/src/main/scala/midas/widgets/Master.scala
@@ -23,18 +23,18 @@ object Pulsify {
       val count = Counter(pulseLength)
       when(in){count.inc()}
       when(count.value === UInt(pulseLength-1)) {
-        in := Bool(false)
+        in := false.B
         count.value := UInt(0)
       }
     } else {
-      when(in) {in := Bool(false)}
+      when(in) {in := false.B}
     }
   }
 }
 
 class EmulationMaster(implicit p: Parameters) extends Widget()(p) {
   val io = IO(new EmulationMasterIO)
-  Pulsify(genWORegInit(io.simReset, "SIM_RESET", Bool(false)), pulseLength = 4)
+  Pulsify(genWORegInit(io.simReset, "SIM_RESET", false.B), pulseLength = 4)
   genAndAttachQueue(io.step, "STEP")
   genRORegInit(io.done && ~io.simReset, "DONE", UInt(0))
 

--- a/src/main/scala/midas/widgets/NastiIO.scala
+++ b/src/main/scala/midas/widgets/NastiIO.scala
@@ -59,10 +59,10 @@ abstract class NastiWidgetBase(implicit p: Parameters) extends MemModel {
   // 3. connect target channels to buffers.
   //   - Transactions are generated / consumed according to timing conditions
   def elaborate(stall: Bool,
-                rCycleValid: Bool = Bool(true),
-                wCycleValid: Bool = Bool(true),
-                rCycleReady: Bool = Bool(true),
-                wCycleReady: Bool = Bool(true)) = {
+                rCycleValid: Bool = true.B,
+                wCycleValid: Bool = true.B,
+                rCycleReady: Bool = true.B,
+                wCycleReady: Bool = true.B) = {
     val fire = tFire && !stall
     fire suggestName "fire"
     io.tNasti.toHost.hReady := fire

--- a/src/main/scala/midas/widgets/NastiIO.scala
+++ b/src/main/scala/midas/widgets/NastiIO.scala
@@ -24,7 +24,7 @@ abstract class EndpointWidget(implicit p: Parameters) extends Widget()(p) {
 
 abstract class MemModelConfig // TODO: delete it
 
-class MemModelIO(implicit p: Parameters) extends EndpointWidgetIO()(p){
+class MemModelIO(implicit val p: Parameters) extends EndpointWidgetIO()(p){
   // The default NastiKey is expected to be that of the target
   val tNasti = Flipped(HostPort(new NastiIO, false))
   val host_mem = new NastiIO()(p.alterPartial({ case NastiKey => p(MemNastiKey)}))

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -65,7 +65,7 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
     val reg = Reg(channel.bits)
     reg suggestName ("target_" + name)
     channel.bits := reg
-    channel.valid := iTokensAvailable =/= UInt(0) && fromHostReady
+    channel.valid := iTokensAvailable =/= 0.U && fromHostReady
     attach(reg, name)
   }) _
 
@@ -73,19 +73,19 @@ class PeekPokeIOWidget(inputs: Seq[(String, Int)], outputs: Seq[(String, Int)])
     val channel = io.outs(offset)
     val reg = RegEnable(channel.bits, channel.fire)
     reg suggestName ("target_" + name)
-    channel.ready := oTokensPending =/= UInt(0) && toHostValid
+    channel.ready := oTokensPending =/= 0.U && toHostValid
     attach(reg, name)
   }) _
 
   val inputAddrs = bindInputs(inputs, 0)
   val outputAddrs = bindOutputs(outputs, 0)
 
-  when (iTokensAvailable =/= UInt(0) && fromHostReady) {
-    iTokensAvailable := iTokensAvailable - UInt(1)
+  when (iTokensAvailable =/= 0.U && fromHostReady) {
+    iTokensAvailable := iTokensAvailable - 1.U
   }
 
-  when (oTokensPending =/= UInt(0) && toHostValid) {
-    oTokensPending := oTokensPending - UInt(1)
+  when (oTokensPending =/= 0.U && toHostValid) {
+    oTokensPending := oTokensPending - 1.U
     tCycle := tCycle + 1.U
   }
   hCycle := hCycle + 1.U

--- a/src/main/scala/midas/widgets/PeekPokeIO.scala
+++ b/src/main/scala/midas/widgets/PeekPokeIO.scala
@@ -27,7 +27,7 @@ trait HasChannels {
   }
 }
 
-class PeekPokeIOWidgetIO(val inNum: Int, val outNum: Int)(implicit p: Parameters)
+class PeekPokeIOWidgetIO(val inNum: Int, val outNum: Int)(implicit val p: Parameters)
     extends WidgetIO()(p) {
   // Channel width == width of simulation MMIO bus
   val ins  = Vec(inNum, Decoupled(UInt(ctrl.nastiXDataBits.W)))

--- a/src/main/scala/midas/widgets/Widget.scala
+++ b/src/main/scala/midas/widgets/Widget.scala
@@ -26,6 +26,8 @@ object WidgetMMIO {
 }
 
 // All widgets must implement this interface
+// NOTE: Changing ParameterizedBundle -> Bundle breaks PeekPokeWidgetIO when
+// outNum = 0
 abstract class WidgetIO(implicit p: Parameters) extends ParameterizedBundle()(p){
   val ctrl = Flipped(WidgetMMIO())
 }

--- a/src/main/scala/strober/widgets/DaisyController.scala
+++ b/src/main/scala/strober/widgets/DaisyController.scala
@@ -18,10 +18,10 @@ class DaisyController(daisyIF: DaisyBundle)(implicit p: Parameters) extends Widg
 
   // Handle SRAM restarts
   io.daisy.sram.zipWithIndex foreach { case (sram, i) =>
-    Pulsify(genWORegInit(sram.restart, s"SRAM_RESTART_$i", Bool(false)), pulseLength = 1)
+    Pulsify(genWORegInit(sram.restart, s"SRAM_RESTART_$i", false.B), pulseLength = 1)
   }
   io.daisy.regfile.zipWithIndex foreach { case (regfile, i) =>
-    Pulsify(genWORegInit(regfile.restart, s"REGFILE_RESTART_$i", Bool(false)), pulseLength = 1)
+    Pulsify(genWORegInit(regfile.restart, s"REGFILE_RESTART_$i", false.B), pulseLength = 1)
   }
 
   def bindDaisyChain[T <: DaisyData](daisy: Vec[T], name: String) = {


### PR DESCRIPTION
Notably leaving out Log2Up because changing that would be dangerous AF.

Checked by diffing output verilog for a couple of different targets. 