### PR TITLE
Fix latency histogram

### DIFF
--- a/src/main/scala/midas/SynthUnitTests.scala
+++ b/src/main/scala/midas/SynthUnitTests.scala
@@ -10,6 +10,7 @@ import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
 
 import freechips.rocketchip.config.{Parameters, Config, Field}
 import freechips.rocketchip.unittest.{UnitTests, TestHarness}
+import midas.models.{CounterTableUnitTest, LatencyHistogramUnitTest}
 
 
 // Unittests
@@ -35,8 +36,9 @@ class WithAllUnitTests extends Config((site, here, up) => {
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(3))),
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(4))),
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(7))),
-      Module(new ReadyValidChannelUnitTest)
-    )
+      Module(new ReadyValidChannelUnitTest),
+      Module(new CounterTableUnitTest),
+      Module(new LatencyHistogramUnitTest))
   }
 })
 

--- a/src/main/scala/midas/SynthUnitTests.scala
+++ b/src/main/scala/midas/SynthUnitTests.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.unittest.{UnitTests, TestHarness}
 
 
 // Unittests
-class WithWireChannelTests extends Config((site, here, up) => {
+class WithAllUnitTests extends Config((site, here, up) => {
   case UnitTests => (q: Parameters) => {
     implicit val p = q
     val timeout = 2000000
@@ -26,16 +26,7 @@ class WithWireChannelTests extends Config((site, here, up) => {
       Module(new WireChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(3))),
       Module(new WireChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(4))),
       Module(new WireChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(7))),
-      Module(new WireChannelUnitTest)
-    )
-  }
-})
-
-class WithReadyValidChannelTests extends Config((site, here, up) => {
-  case UnitTests => (q: Parameters) => {
-    implicit val p = q
-    val timeout = 200000
-    Seq(
+      Module(new WireChannelUnitTest),
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = ReciprocalClockRatio(2))),
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = ReciprocalClockRatio(3))),
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = ReciprocalClockRatio(4))),
@@ -60,7 +51,7 @@ class WithTimeOutCheck extends Config((site, here, up) => {
 })
 
 // Complete configs
-class AllUnitTests extends Config(new WithReadyValidChannelTests ++ new WithWireChannelTests ++ new SimConfig)
+class AllUnitTests extends Config(new WithAllUnitTests ++ new SimConfig)
 class TimeOutCheck extends Config(new WithTimeOutCheck ++ new SimConfig)
 
 // Generates synthesizable unit tests for key modules, such as simulation channels


### PR DESCRIPTION
Previously, the logic for bypassing SRAM updates in the LatencyHistogram was incorrect. This fixes that issue and a few other things:

1. Fix the bypass path issue.
2. Cleanly abstract the counter SRAM into a reusable module.
3. Add synthesizable unit tests.
4. Fix the AllUnitTests config class.