### PR TITLE
Address range counters

### DIFF
--- a/src/main/cc/endpoints/fpga_memory_model.cc
+++ b/src/main/cc/endpoints/fpga_memory_model.cc
@@ -30,13 +30,13 @@ void Histogram::finish() {
 }
 
 void AddrRangeCounter::init() {
-  nranges = read64("numRangesH", "numRangesL", NUM_RANGE_MASK);
+  nranges = read("numRanges");
   range_bytes = new uint64_t[nranges];
 
   write(enable, 1);
   for (size_t i = 0; i < nranges; i++) {
     write(addr, i);
-    range_bytes[i] = read64(dataH, dataL, RANGE_BYTES_MASK);
+    range_bytes[i] = read64(dataH, dataL, RANGE_H_MASK);
   }
   write(enable, 0);
 }
@@ -45,14 +45,15 @@ void AddrRangeCounter::finish() {
   write(enable, 1);
   for (size_t i = 0; i < nranges; i++) {
     write(addr, i);
-    range_bytes[i] = read64(dataH, dataL, RANGE_BYTES_MASK);
+    range_bytes[i] = read64(dataH, dataL, RANGE_H_MASK);
   }
   write(enable, 0);
 }
 
 FpgaMemoryModel::FpgaMemoryModel(
-    simif_t* sim, AddressMap addr_map, int argc, char** argv, std::string stats_file_name)
-  : FpgaModel(sim, addr_map){
+    simif_t* sim, AddressMap addr_map, int argc, char** argv,
+    std::string stats_file_name, size_t mem_size)
+  : FpgaModel(sim, addr_map), mem_size(mem_size) {
 
   std::vector<std::string> args(argv + 1, argv + argc);
   for (auto &arg: args) {
@@ -175,7 +176,7 @@ void FpgaMemoryModel::finish() {
     rangectr_file << std::endl;
 
     for (size_t i = 0; i < nranges; i++) {
-      rangectr_file << std::hex << (i * MEM_SIZE / nranges) << ",";
+      rangectr_file << std::hex << (i * mem_size / nranges) << ",";
       for (auto &rctr: rangectrs) {
         rangectr_file << std::dec << rctr.range_bytes[i] << ",";
       }

--- a/src/main/cc/endpoints/fpga_memory_model.h
+++ b/src/main/cc/endpoints/fpga_memory_model.h
@@ -13,10 +13,9 @@
 // MICRO HACKS.
 constexpr int HISTOGRAM_SIZE = 1024;
 constexpr int BIN_SIZE = 36;
+constexpr int RANGE_COUNT_SIZE = 48;
 constexpr data_t BIN_H_MASK = (1L << (BIN_SIZE - 32)) - 1;
-constexpr data_t NUM_RANGE_MASK = (1L << 4) - 1;
-constexpr data_t RANGE_BYTES_MASK = (1L << 16) - 1;
-constexpr uint64_t MEM_SIZE (1L << 35);
+constexpr data_t RANGE_H_MASK = (1L << (RANGE_COUNT_SIZE - 32)) - 1;
 
 class AddrRangeCounter: public FpgaModel {
   public:
@@ -59,7 +58,7 @@ class FpgaMemoryModel: public FpgaModel
 {
 public:
   FpgaMemoryModel(simif_t* s, AddressMap addr_map, int argc, char** argv,
-                  std::string stats_file_name);
+                  std::string stats_file_name, size_t mem_size);
   void init();
   void profile();
   void finish();
@@ -79,7 +78,8 @@ private:
     "Ranges_dataL",
     "Ranges_dataH",
     "Ranges_addr",
-    "Ranges_enable"
+    "Ranges_enable",
+    "numRanges"
   };
 
   std::set<std::string> profile_exclusion {
@@ -90,10 +90,12 @@ private:
     "Ranges_dataL",
     "Ranges_dataH",
     "Ranges_addr",
-    "Ranges_enable"
+    "Ranges_enable",
+    "numRanges"
   };
 
   bool has_latency_histograms() { return histograms.size() > 0; };
+  size_t mem_size;
 };
 
 #endif // __FPGA_MEMORY_MODEL_H

--- a/src/main/cc/endpoints/fpga_memory_model.h
+++ b/src/main/cc/endpoints/fpga_memory_model.h
@@ -14,6 +14,30 @@
 constexpr int HISTOGRAM_SIZE = 1024;
 constexpr int BIN_SIZE = 36;
 constexpr data_t BIN_H_MASK = (1L << (BIN_SIZE - 32)) - 1;
+constexpr data_t NUM_RANGE_MASK = (1L << 4) - 1;
+constexpr data_t RANGE_BYTES_MASK = (1L << 16) - 1;
+constexpr uint64_t MEM_SIZE (1L << 35);
+
+class AddrRangeCounter: public FpgaModel {
+  public:
+    AddrRangeCounter(simif_t *sim, AddressMap addr_map, std::string name):
+      FpgaModel(sim, addr_map), name(name) {};
+    ~AddrRangeCounter(void) { /*delete [] range_bytes;*/ }
+
+    void init();
+    void profile() {}
+    void finish();
+
+    std::string name;
+    uint64_t *range_bytes;
+    size_t nranges;
+
+  private:
+    std::string enable = name + "Ranges_enable";
+    std::string dataH  = name + "Ranges_dataH";
+    std::string dataL  = name + "Ranges_dataL";
+    std::string addr   = name + "Ranges_addr";
+};
 
 class Histogram: public FpgaModel {
 public:
@@ -46,18 +70,27 @@ private:
   std::vector<uint32_t> profile_reg_addrs;
   std::ofstream stats_file;
   std::vector<Histogram> histograms;
+  std::vector<AddrRangeCounter> rangectrs;
   std::set<std::string> configuration_exclusion {
     "Hist_dataL",
     "Hist_dataH",
     "Hist_addr",
-    "Hist_enable"
+    "Hist_enable",
+    "Ranges_dataL",
+    "Ranges_dataH",
+    "Ranges_addr",
+    "Ranges_enable"
   };
 
   std::set<std::string> profile_exclusion {
     "Hist_dataL",
     "Hist_dataH",
     "Hist_addr",
-    "Hist_enable"
+    "Hist_enable",
+    "Ranges_dataL",
+    "Ranges_dataH",
+    "Ranges_addr",
+    "Ranges_enable"
   };
 
   bool has_latency_histograms() { return histograms.size() > 0; };

--- a/src/main/cc/simif_emul.cc
+++ b/src/main/cc/simif_emul.cc
@@ -57,7 +57,7 @@ void simif_emul_t::init(int argc, char** argv, bool log) {
   std::string loadmem;
   bool fastloadmem = false;
   bool dramsim = false;
-  uint64_t memsize = 1L << 32;
+  uint64_t memsize = 1L << MEM_ADDR_BITS;
   for (auto arg: args) {
     if (arg.find("+waveform=") == 0) {
       waveform = arg.c_str() + 10;

--- a/src/main/scala/midas/SynthUnitTests.scala
+++ b/src/main/scala/midas/SynthUnitTests.scala
@@ -10,7 +10,7 @@ import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
 
 import freechips.rocketchip.config.{Parameters, Config, Field}
 import freechips.rocketchip.unittest.{UnitTests, TestHarness}
-import midas.models.{CounterTableUnitTest, LatencyHistogramUnitTest}
+import midas.models.{CounterTableUnitTest, LatencyHistogramUnitTest, AddressRangeCounterUnitTest}
 
 
 // Unittests
@@ -38,7 +38,8 @@ class WithAllUnitTests extends Config((site, here, up) => {
       Module(new ReadyValidChannelUnitTest(timeout = timeout, clockRatio = IntegralClockRatio(7))),
       Module(new ReadyValidChannelUnitTest),
       Module(new CounterTableUnitTest),
-      Module(new LatencyHistogramUnitTest))
+      Module(new LatencyHistogramUnitTest),
+      Module(new AddressRangeCounterUnitTest))
   }
 })
 

--- a/src/main/scala/midas/models/dram/MidasMemModel.scala
+++ b/src/main/scala/midas/models/dram/MidasMemModel.scala
@@ -383,8 +383,6 @@ class MidasMemModel(cfg: BaseConfig)(implicit p: Parameters) extends MemModel {
     val writeRanges = AddressRangeCounter(n, model.io.tNasti.aw, targetFire)
     val numRanges = n.U(32.W)
 
-    require(n < (1L << 32))
-
     attachIO(readRanges, "readRanges_")
     attachIO(writeRanges, "writeRanges_")
     attach(numRanges, "numRanges", ReadOnly)

--- a/src/main/scala/midas/models/dram/MidasMemModel.scala
+++ b/src/main/scala/midas/models/dram/MidasMemModel.scala
@@ -381,13 +381,13 @@ class MidasMemModel(cfg: BaseConfig)(implicit p: Parameters) extends MemModel {
     val n = cfg.params.addrRangeCounters
     val readRanges = AddressRangeCounter(n, model.io.tNasti.ar, targetFire)
     val writeRanges = AddressRangeCounter(n, model.io.tNasti.aw, targetFire)
-    val addrBits = model.io.tNasti.nastiXAddrBits
-    val numRanges = n.U(addrBits.W)
+    val numRanges = n.U(32.W)
+
+    require(n < (1L << 32))
 
     attachIO(readRanges, "readRanges_")
     attachIO(writeRanges, "writeRanges_")
-    attach(numRanges(31, 0), "numRangesL", ReadOnly)
-    attach(numRanges(addrBits-1, 32), "numRangesH", ReadOnly)
+    attach(numRanges, "numRanges", ReadOnly)
   }
 
   val rrespError = RegEnable(io.host_mem.r.bits.resp, 0.U,
@@ -415,6 +415,9 @@ class MidasMemModel(cfg: BaseConfig)(implicit p: Parameters) extends MemModel {
     super.genHeader(base, sb)
 
     crRegistry.genArrayHeader(wName.getOrElse(name).toUpperCase, base, sb)
+
+    val targetAddrBits = model.io.tNasti.nastiXAddrBits
+    sb.append(genMacro("TARGET_MEM_ADDR_BITS", UInt32(targetAddrBits)))
   }
 
   // Prints out key elaboration time settings

--- a/src/main/scala/midas/models/dram/Util.scala
+++ b/src/main/scala/midas/models/dram/Util.scala
@@ -548,6 +548,7 @@ class AddressRangeCounter(nRanges: BigInt)(implicit p: Parameters) extends Nasti
   })
 
   require(nRanges > 1)
+  require(nRanges < (1L << 32))
   require(isPow2(nRanges))
 
   val counterBits = 48


### PR DESCRIPTION
These commits add the option for a new type of counter. The address range gets split into N equal-sized buckets (N must be power of 2) and each range gets a counter that records how many bytes of data have been read from or written to the range. Currently, these counts are only read after the simulation finishes. We could add an option to read the counters in profile(), but it would make simulation much slower.