### PR TITLE
Fix verilog header emission to remove L suffix

### DIFF
--- a/src/main/scala/midas/passes/PlatformMapping.scala
+++ b/src/main/scala/midas/passes/PlatformMapping.scala
@@ -20,7 +20,7 @@ private[passes] class PlatformMapping(
   override def name = "[MIDAS] Platform Mapping"
 
   private def dumpHeader(c: platform.PlatformShim) {
-    def vMacro(arg: (String, Long)): String = s"`define ${arg._1} ${arg._2}L\n"
+    def vMacro(arg: (String, Long)): String = s"`define ${arg._1} ${arg._2}\n"
 
     val csb = new StringBuilder
     csb append "#ifndef __%s_H\n".format(target.toUpperCase)


### PR DESCRIPTION
This is only a problem for certain versions of verilator and VCS. 