### PR TITLE
Print Synthesis Improvements

### DIFF
--- a/src/main/cc/endpoints/synthesized_prints.cc
+++ b/src/main/cc/endpoints/synthesized_prints.cc
@@ -32,7 +32,7 @@ synthesized_prints_t::synthesized_prints_t(
   this->start_cycle = 0;
   this->end_cycle = -1ULL;
 
-  std::string printfile_arg  = std::string("+printfile=");
+  std::string printfile_arg  = std::string("+print-file=");
   std::string printstart_arg = std::string("+print-start=");
   std::string printend_arg   = std::string("+print-end=");
   std::string humanreadable_arg   = std::string("+print-human-readable");

--- a/src/main/cc/endpoints/synthesized_prints.cc
+++ b/src/main/cc/endpoints/synthesized_prints.cc
@@ -181,8 +181,8 @@ void synthesized_prints_t::print_format(const char* fmt, print_vars_t* vars, pri
 // Returns true if at least one print in the token is enabled in this cycle
 bool has_enabled_print(char * buf) { return (buf[0] & 1); }
 // If the token has no enabled prints, return a number of idle cycles encoded in the msbs
-bool decode_idle_cycles(char * buf, uint32_t mask) {
-  return ((*((uint32_t*)buf)) & mask) >> 1;
+uint32_t decode_idle_cycles(char * buf, uint32_t mask) {
+  return (((*((uint32_t*)buf)) & mask) >> 1);
 }
 
 // Iterates through the DMA flits (each is one token); checking if their are enabled prints

--- a/src/main/cc/endpoints/synthesized_prints.cc
+++ b/src/main/cc/endpoints/synthesized_prints.cc
@@ -1,5 +1,7 @@
 #ifdef PRINTWIDGET_struct_guard
 
+#include <iomanip>
+
 #include "synthesized_prints.h"
 
 synthesized_prints_t::synthesized_prints_t(
@@ -35,7 +37,10 @@ synthesized_prints_t::synthesized_prints_t(
   std::string printfile_arg  = std::string("+print-file=");
   std::string printstart_arg = std::string("+print-start=");
   std::string printend_arg   = std::string("+print-end=");
+  // Properly formats the printfs, before writing them to file
   std::string humanreadable_arg   = std::string("+print-human-readable");
+  // In human-readable mode, when set, prefixes each print with the cycle number
+  std::string cycleprefix_arg   = std::string("+print-cycle-prefix");
 
   // Choose a multiple of token_bytes for the batch size
   if (((beat_bytes * desired_batch_beats) % token_bytes) != 0 ) {
@@ -58,6 +63,9 @@ synthesized_prints_t::synthesized_prints_t(
       }
       if (arg.find(humanreadable_arg) == 0) {
           human_readable = true;
+      }
+      if (arg.find(cycleprefix_arg) == 0) {
+          print_cycle_prefix = true;
       }
   }
   current_cycle = start_cycle; // We won't receive tokens until start_cycle; so fast-forward
@@ -130,6 +138,9 @@ void synthesized_prints_t::init() {
 // print to the desired stream
 void synthesized_prints_t::print_format(const char* fmt, print_vars_t* vars, print_vars_t* masks) {
   size_t k = 0;
+  if (print_cycle_prefix) {
+    *printstream << "CYCLE:" << std::setw(13) << current_cycle << " ";
+  }
   while(*fmt) {
     if (*fmt == '%' && fmt[1] != '%') {
       mpz_t* value = vars->data[k];

--- a/src/main/cc/endpoints/synthesized_prints.cc
+++ b/src/main/cc/endpoints/synthesized_prints.cc
@@ -178,7 +178,13 @@ bool decode_idle_cycles(char * buf, uint32_t mask) {
 void synthesized_prints_t::process_tokens(size_t beats) {
   size_t batch_bytes = beats * beat_bytes;
   char buf[batch_bytes];
-  pull(dma_address, (char*)buf, batch_bytes);
+  uint32_t bytes_received = pull(dma_address, (char*)buf, batch_bytes);
+  if (bytes_received != batch_bytes) {
+    printf("ERR MISMATCH! on reading print tokens. Read %d bytes, wanted %d bytes.\n",
+           bytes_received, batch_bytes);
+    printf("errno: %s\n", strerror(errno));
+    exit(1);
+  }
 
   if (human_readable) {
     for (size_t idx = 0; idx < batch_bytes; idx += token_bytes ) {

--- a/src/main/cc/endpoints/synthesized_prints.h
+++ b/src/main/cc/endpoints/synthesized_prints.h
@@ -68,13 +68,14 @@ class synthesized_prints_t: public endpoint_t
 
 
         // +arg driven members
-        std::ofstream printfile;   // Used only if the +printfile arg is provided
+        std::ofstream printfile;   // Used only if the +print-file arg is provided
         std::string default_filename = "synthesized-prints.out";
 
         std::ostream* printstream; // Is set to std::cerr otherwise
         uint64_t start_cycle, end_cycle; // Bounds between which prints will be emitted
         uint64_t current_cycle = 0;
         bool human_readable = false;
+        bool print_cycle_prefix = false;
 
         std::vector<std::vector<size_t>> widths;
         std::vector<size_t> sizes;

--- a/src/main/cc/endpoints/synthesized_prints.h
+++ b/src/main/cc/endpoints/synthesized_prints.h
@@ -59,7 +59,7 @@ class synthesized_prints_t: public endpoint_t
         // This will be set based on the ratio of token_size : desired_batch_beats
         size_t batch_beats;
         // This will be modified to be a multiple of the token size
-        const size_t desired_batch_beats = 6144;
+        const size_t desired_batch_beats = 16; // Should be larger. see firesim #208
 
         // Used to define the boundaries in the batch buffer at which we'll
         // initalize GMP types

--- a/src/main/cc/endpoints/synthesized_prints.h
+++ b/src/main/cc/endpoints/synthesized_prints.h
@@ -59,7 +59,7 @@ class synthesized_prints_t: public endpoint_t
         // This will be set based on the ratio of token_size : desired_batch_beats
         size_t batch_beats;
         // This will be modified to be a multiple of the token size
-        const size_t desired_batch_beats = 16; // Should be larger. see firesim #208
+        const size_t desired_batch_beats = 3072;
 
         // Used to define the boundaries in the batch buffer at which we'll
         // initalize GMP types

--- a/src/main/scala/midas/widgets/Print.scala
+++ b/src/main/scala/midas/widgets/Print.scala
@@ -78,7 +78,7 @@ class PrintWidget(printRecord: PrintRecordBag)(implicit p: Parameters) extends E
     with UnidirectionalDMAToHostCPU {
   val io = IO(new PrintWidgetIO(printRecord))
   lazy val toHostCPUQueueDepth = 6144 // 12 Ultrascale+ URAMs
-  lazy val dmaSize = BigInt(512 * 4)
+  lazy val dmaSize = BigInt(dmaBytes * toHostCPUQueueDepth)
 
   val printPort = io.hPort.hBits
   // Pick a padded token width that's a power of 2 bytes, including enable bit

--- a/targetutils/src/main/scala/midas/annotations.scala
+++ b/targetutils/src/main/scala/midas/annotations.scala
@@ -17,11 +17,17 @@ case class FpgaDebugAnnotation(target: chisel3.Data) extends ChiselAnnotation {
   def toFirrtl = FirrtlFpgaDebugAnnotation(target.toNamed)
 }
 
-case class FirrtlFpgaDebugAnnotation(target: ComponentName) extends
+private [midas] case class FirrtlFpgaDebugAnnotation(target: ComponentName) extends
     SingleTargetAnnotation[ComponentName] {
   def duplicate(n: ComponentName) = this.copy(target = n)
 }
 
+object FpgaDebug {
+  def apply(targets: chisel3.Data*): Unit = {
+    targets.map({ t => chisel3.experimental.annotate(FpgaDebugAnnotation(t)) })
+    targets.map(dontTouch(_))
+  }
+}
 
 private[midas] class ReferenceTargetRenamer(renames: RenameMap) {
   // TODO: determine order for multiple renames, or just check of == 1 rename?


### PR DESCRIPTION
Summary of changes: 
- +printfile -> +print-file for consistency with other plusargs
- Adds an optional cycle prefix in human-readable mode (set with +print-cycle-prefix)
- Aligns destination buffer to page-boundary to fix DMA bug (see firesim/firesim#208) 