### PR TITLE
Add support for parameterizing FASED memory timing-models with diplomatic edges

### DIFF
--- a/src/main/scala/midas/models/dram/BankConflictModel.scala
+++ b/src/main/scala/midas/models/dram/BankConflictModel.scala
@@ -13,10 +13,10 @@ import Console.{UNDERLINED, RESET}
 case class BankConflictConfig(
     maxBanks: Int,
     maxLatencyBits: Int = 12, // 4K cycles
-    baseParams: BaseParams)
-  extends BaseConfig(baseParams) {
+    baseParams: BaseParams)(implicit p: Parameters)
+  extends BaseConfig(baseParams)(p) {
 
-  def elaborate()(implicit p: Parameters): BankConflictModel = Module(new BankConflictModel(this))
+  def elaborate(): BankConflictModel = Module(new BankConflictModel(this))
 }
 
 class BankConflictMMRegIO(cfg: BankConflictConfig) extends SplitTransactionMMRegIO(cfg: BaseConfig){

--- a/src/main/scala/midas/models/dram/DramCommon.scala
+++ b/src/main/scala/midas/models/dram/DramCommon.scala
@@ -107,7 +107,8 @@ class DRAMProgrammableTimings extends Bundle with HasDRAMMASConstants with HasPr
 
 case class DRAMBackendKey(writeDepth: Int, readDepth: Int, latencyBits: Int)
 
-abstract class DRAMBaseConfig( baseParams: BaseParams) extends BaseConfig(baseParams) with HasDRAMMASConstants {
+abstract class DRAMBaseConfig( baseParams: BaseParams)(implicit p: Parameters)
+    extends BaseConfig(baseParams)(p) with HasDRAMMASConstants {
   def dramKey: DramOrganizationParams
   def backendKey: DRAMBackendKey
 }

--- a/src/main/scala/midas/models/dram/FIFOMASModel.scala
+++ b/src/main/scala/midas/models/dram/FIFOMASModel.scala
@@ -13,10 +13,10 @@ case class FIFOMASConfig(
     dramKey: DramOrganizationParams,
     transactionQueueDepth: Int,
     backendKey: DRAMBackendKey = DRAMBackendKey(4, 4, DRAMMasEnums.maxDRAMTimingBits),
-    baseParams: BaseParams)
-  extends DRAMBaseConfig(baseParams) {
+    baseParams: BaseParams)(implicit p: Parameters)
+  extends DRAMBaseConfig(baseParams)(p) {
 
-  def elaborate()(implicit p: Parameters): FIFOMASModel = Module(new FIFOMASModel(this))
+  def elaborate(): FIFOMASModel = Module(new FIFOMASModel(this)(p))
 }
 
 class FIFOMASMMRegIO(val cfg: FIFOMASConfig) extends BaseDRAMMMRegIO(cfg) {

--- a/src/main/scala/midas/models/dram/FRFCFSModel.scala
+++ b/src/main/scala/midas/models/dram/FRFCFSModel.scala
@@ -17,10 +17,10 @@ case class FirstReadyFCFSConfig(
     schedulerWindowSize: Int,
     transactionQueueDepth: Int,
     backendKey: DRAMBackendKey = DRAMBackendKey(4, 4, DRAMMasEnums.maxDRAMTimingBits),
-    baseParams: BaseParams)
-  extends DRAMBaseConfig(baseParams) {
+    baseParams: BaseParams)(implicit p: Parameters)
+  extends DRAMBaseConfig(baseParams)(p) {
 
-  def elaborate()(implicit p: Parameters): FirstReadyFCFSModel = Module(new FirstReadyFCFSModel(this))
+  def elaborate(): FirstReadyFCFSModel = Module(new FirstReadyFCFSModel(this))
 }
 
 class FirstReadyFCFSMMRegIO(val cfg: FirstReadyFCFSConfig) extends BaseDRAMMMRegIO(cfg) {

--- a/src/main/scala/midas/models/dram/IngressUnit.scala
+++ b/src/main/scala/midas/models/dram/IngressUnit.scala
@@ -33,6 +33,7 @@ import midas.widgets.{SatUpDownCounter}
 
 trait IngressModuleParameters {
   val cfg: BaseConfig
+  implicit val p: Parameters
   // In general the only consequence of undersizing these are more wasted
   // host cycles the model waits to drain these
   val ingressAWQdepth = cfg.maxWrites

--- a/src/main/scala/midas/models/dram/LatencyBandwidthPipe.scala
+++ b/src/main/scala/midas/models/dram/LatencyBandwidthPipe.scala
@@ -10,8 +10,9 @@ import midas.widgets._
 
 import Console.{UNDERLINED, RESET}
 
-case class LatencyPipeConfig(baseParams: BaseParams) extends BaseConfig(baseParams) {
-  def elaborate()(implicit p:Parameters): LatencyPipe = Module(new LatencyPipe(this))
+case class LatencyPipeConfig(baseParams: BaseParams)(implicit p: Parameters)
+    extends BaseConfig(baseParams)(p) {
+  def elaborate(): LatencyPipe = Module(new LatencyPipe(this))
 }
 
 class LatencyPipeMMRegIO(cfg: BaseConfig) extends SplitTransactionMMRegIO(cfg){

--- a/src/main/scala/midas/models/dram/TargetToHostAXI4Converter.scala
+++ b/src/main/scala/midas/models/dram/TargetToHostAXI4Converter.scala
@@ -22,7 +22,7 @@ class TargetToHostAXI4Converter (
     mMaxTransfer: Int = 128)
   (implicit p: Parameters) extends LazyModule
 {
-  implicit val roflname = ValName("AXI4GhettoWidthAdapter")
+  implicit val valname = ValName("FASEDWidthAdapter")
   val m   = AXI4MasterNode(Seq(AXI4MasterPortParameters(
     masters = Seq(AXI4MasterParameters(
       name = "widthAdapter",

--- a/src/main/scala/midas/models/dram/TimingModel.scala
+++ b/src/main/scala/midas/models/dram/TimingModel.scala
@@ -90,6 +90,8 @@ abstract class TimingModel(val cfg: BaseConfig)(implicit val p: Parameters) exte
   val wResp = Wire(Decoupled(new WriteResponseMetaData))
   val rResp = Wire(Decoupled(new ReadResponseMetaData))
 
+  val monitor = Module(new MemoryModelMonitor(cfg))
+  monitor.axi4 := io.tNasti
 
   val tCycle = RegInit(0.U(64.W))
   tCycle := tCycle + 1.U

--- a/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/src/main/scala/midas/passes/MidasTransforms.scala
@@ -59,8 +59,7 @@ private[midas] class MidasTransforms(
       // Any subFields must be flattened out beforing linking in HighForm constructs must Lower 
       firrtl.CompilerUtils.getLoweringTransforms(HighForm, LowForm) ++ Seq(
         new SimulationMapping(io),
-        new PlatformMapping(state.circuit.main, dir),
-        new EmitFirrtl("post-platform-mapping.fir")
+        new PlatformMapping(state.circuit.main, dir)
       )
       (xforms foldLeft state)((in, xform) =>
         xform runTransform in).copy(form=outputForm)

--- a/src/main/scala/midas/passes/MidasTransforms.scala
+++ b/src/main/scala/midas/passes/MidasTransforms.scala
@@ -59,7 +59,9 @@ private[midas] class MidasTransforms(
       // Any subFields must be flattened out beforing linking in HighForm constructs must Lower 
       firrtl.CompilerUtils.getLoweringTransforms(HighForm, LowForm) ++ Seq(
         new SimulationMapping(io),
-        new PlatformMapping(state.circuit.main, dir))
+        new PlatformMapping(state.circuit.main, dir),
+        new EmitFirrtl("post-platform-mapping.fir")
+      )
       (xforms foldLeft state)((in, xform) =>
         xform runTransform in).copy(form=outputForm)
   }


### PR DESCRIPTION
Associated firesim PR: firesim/firesim#231. 
Prevents a number of foot-shooting modes. 