### PR TITLE
Heterogeneous mem channels

### DIFF
--- a/src/main/cc/rtlsim/Makefrag-vcs
+++ b/src/main/cc/rtlsim/Makefrag-vcs
@@ -19,7 +19,6 @@ override VCS_FLAGS := -quiet -timescale=1ns/1ps +v2k +rad +vcs+initreg+random +v
 	-sverilog \
 	+define+CLOCK_PERIOD=$(CLOCK_PERIOD) \
 	+define+RANDOMIZE_MEM_INIT \
-	+define+RANDOMIZE_REG_INIT \
 	+define+RANDOMIZE_GARBAGE_ASSIGN \
 	+define+RANDOMIZE_INVALID_ASSIGN \
 	+define+STOP_COND=!$(TB).reset \

--- a/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
+++ b/src/main/scala/midas/models/dram/FASEDMemoryTimingModel.scala
@@ -477,9 +477,6 @@ class FASEDMemoryTimingModel(cfg: BaseConfig)(implicit p: Parameters) extends En
     sb.append(CppGenerationUtils.genMacro(s"${getWName.toUpperCase}_target_addr_bits", UInt32(p(NastiKey).addrBits)))
 
     crRegistry.genArrayHeader(wName.getOrElse(name).toUpperCase, base, sb)
-
-    val targetAddrBits = model.io.tNasti.nastiXAddrBits
-    sb.append(genMacro("TARGET_MEM_ADDR_BITS", UInt32(targetAddrBits)))
   }
 
   // Prints out key elaboration time settings


### PR DESCRIPTION
Some fixes that I'm cherry-picking from my DRAM cache branch.

1. Don't set RANDOMIZE_REG_INIT for the FIRRTL-generated verilog. Rely on simulation tools initializing registers to 0.
2. Allow memory channels to have different memory sizes (and thus different address widths), but they must still all use the same memory model.