### PR TITLE
[ml-sim] Add simple host (mmio, dma) timing fuzzing

### DIFF
--- a/src/main/cc/simif_emul.h
+++ b/src/main/cc/simif_emul.h
@@ -1,7 +1,7 @@
 // See LICENSE for license details.
 
-#ifndef __SIMIF_VERILATOR_H
-#define __SIMIF_VERILATOR_H
+#ifndef __SIMIF_EMUL_H
+#define __SIMIF_EMUL_H
 
 #include <memory>
 
@@ -10,6 +10,8 @@
 #include "mm_dramsim2.h"
 #include "emul/mmio.h"
 
+// simif_emul_t is a concrete simif_t implementation for Software RTL simulators
+// The basis for MIDAS-level simulation
 class simif_emul_t : public virtual simif_t
 {
   public:
@@ -24,8 +26,13 @@ class simif_emul_t : public virtual simif_t
     virtual ssize_t push(size_t addr, char* data, size_t size);
 
   private:
+    // The maximum number of cycles the RTL simulator can advance before
+    // switching back to the driver process. +fuzz-host-timings sets this to a value > 1, introducing random delays
+    // in MMIO (read, write) and DMA (push, pull) requests
+    int maximum_host_delay = 1;
+    void advance_target();
     void wait_read(std::unique_ptr<mmio_t>& mmio, void *data);
     void wait_write(std::unique_ptr<mmio_t>& mmio);
 };
 
-#endif // __SIMIF_VERILATOR_H
+#endif // __SIMIF_EMUL_H


### PR DESCRIPTION
The default midas-level simulation simif_t implementation models impossibly fast host transaction latencies on DMA and MMIO. This PR adds some simple fuzzing to the timing on these requests by allowing the FPGA-hosted component to run up to `maximum_host_delay` cycles before switching back to simulation driver. This can be set with the plusarg `+fuzz-host-timing=<int>`. 